### PR TITLE
v2.0.0 – Major refactor to register-based architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,22 +7,22 @@ It is tested on **ECL 120**, but **ECL 220 uses the same register map**, so it *
 ## 🔧 Features
 Current supported features:
 
-### Temperature Sensors
-| Sensor | Register | Description |
-|--------|----------|-------------|
-| **S1 Temperature** | 4000 | Current value of temperature sensor S1 |
-| **S2 Temperature** | 4010 | Current value of temperature sensor S2 |
-| **S3 Temperature** | 4020 | Current value of temperature sensor S3 |
-| **S4 Temperature** | 4030 | Current value of temperature sensor S4 |
-| **S5 Temperature** | 4040 | Current value of temperature sensor S5 |
-| **S6 Temperature** | 4050 | Current value of temperature sensor S6 |
-
-### Additional Calculated Values
-| Name | Register | Type | Description |
-|------|----------|-------|-------------|
-| **Valve Position** | 21700 | Float (%) | Actual valve opening position |
-| **Heat Flow Temperature Reference** | 21200 | Float (°C) | Calculated heat flow reference |
-| **Heat Return Temperature Reference** | 21210 | Float (°C) | Reference for Return Limiter |
+| **Addr** | **RW** | **Name**                               | **Type** | **Unit** | **Min** | **Max** | **Description**                                                                   |
+|----------|--------|----------------------------------------|----------|----------|---------|---------|-----------------------------------------------------------------------------------|
+| 4000     |    R   | **Value of Temperature Sensor S1**     | Float    | °C       | -64     | 192     | Current value of temperature sensor S1                                            |
+| 4010     |    R   | **Value of Temperature Sensor S2**     | Float    | °C       | -64     | 192     | Current value of temperature sensor S2                                            |
+| 4020     |    R   | **Value of Temperature Sensor S3**     | Float    | °C       | -64     | 192     | Current value of temperature sensor S3                                            |
+| 4030     |    R   | **Value of Temperature Sensor S4**     | Float    | °C       | -64     | 192     | Current value of temperature sensor S4                                            |
+| 4040     |    R   | **Value of Temperature Sensor S5**     | Float    | °C       | -64     | 192     | Current value of temperature sensor S5                                            |
+| 4050     |    R   | **Value of Temperature Sensor S6**     | Float    | °C       | -64     | 192     | Current value of temperature sensor S6                                            |
+| 2100     |    R   | **Ethernet IP Address**                | String16 |          |         |         | Ethernet IP Address                                                               |
+| 2110     |    R   | **Ethernet MAC Address**               | String32 |          |         |         | Ethernet MAC Address                                                              |
+| 21000    |   RW   | **Operation Mode**                     | UInt16   |          | 0       | 10      | Current operation mode: 0 = Automatic 1 = Comfort 2 = Saving 3 = Frost protection |
+| 21001    |    R   | **Operation Status**                   | UInt16   |          | 0       | 10      | Current operation status: 0 = Comfort 1 = Saving 2 = Frost Protection             |
+| 21200    |    R   | **Heat Flow Temperature Reference**    | Float    | °C       | 0       | 150     | Calculated heat flow reference                                                    |
+| 21206    |    R   | **Heat Weather Compensated Reference** | Float    | °C       | -150    | 150     | Calculated value from the weather compensator                                     |
+| 21210    |   RW   | **Heat Return Temperature Reference**  | Float    | °C       | 5       | 150     | Reference for Return Limiter                                                      |
+| 21700    |    R   | **Heat Valve Position**                | Float    | %        | 0       | 1       | Scale 100 – Estimated position of motor                                           |
 
 ### Fully configurable
 - Enable/disable each sensor individually  

--- a/custom_components/ecl_modbus/__init__.py
+++ b/custom_components/ecl_modbus/__init__.py
@@ -2,46 +2,104 @@ from __future__ import annotations
 
 """Home Assistant entry points for the ECL Modbus integration."""
 
+from typing import Any
+
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_NAME, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DOMAIN, PLATFORMS
+from .const import (
+    DOMAIN,
+    PLATFORMS,
+    DEFAULT_BAUDRATE,
+    DEFAULT_NAME,
+    DEFAULT_SCAN_INTERVAL,
+    DEFAULT_SLAVE_ID,
+    CONF_BAUDRATE,
+    CONF_SCAN_INTERVAL,
+    CONF_SLAVE_ID,
+)
+from .modbus import EclModbusCoordinator, EclModbusHub
+from .registers import ALL_REGISTERS, option_key
+
+
+def _clamp_scan_interval(value: Any) -> int:
+    try:
+        sec = int(value)
+    except (TypeError, ValueError):
+        sec = DEFAULT_SCAN_INTERVAL
+    return max(5, min(3600, sec))
+
+
+def _default_enabled_key(reg_key: str) -> bool:
+    return reg_key in {"s3_temperature", "s4_temperature"}
+
+
+def _entry_store(hass: HomeAssistant, entry: ConfigEntry) -> dict[str, Any]:
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    store = domain_data.get(entry.entry_id)
+    if not isinstance(store, dict):
+        store = {}
+        domain_data[entry.entry_id] = store
+    return store
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Basic setup from YAML (not used, but required by Home Assistant)."""
     return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up ECL Modbus from a config entry created via the UI."""
-    hass.data.setdefault(DOMAIN, {})
+    """Create hub+coordinator and forward to platforms."""
+    store = _entry_store(hass, entry)
 
-    # Forward the config entry to all platforms (sensor, number, etc.)
+    # Build enabled register list from options
+    enabled_regs = []
+    for reg in ALL_REGISTERS:
+        enabled = bool(
+            entry.options.get(option_key(reg.key), _default_enabled_key(reg.key))
+        )
+        if enabled:
+            enabled_regs.append(reg)
+
+    # Reuse hub if it already exists (prevents serial port lock issues on reload)
+    hub = store.get("hub")
+    if not isinstance(hub, EclModbusHub):
+        hub = EclModbusHub(
+            port=entry.data[CONF_PORT],
+            baudrate=entry.data.get(CONF_BAUDRATE, DEFAULT_BAUDRATE),
+            slave_id=entry.data.get(CONF_SLAVE_ID, DEFAULT_SLAVE_ID),
+        )
+        store["hub"] = hub
+
+    # Create a fresh coordinator every setup (uses current enabled_regs + scan_interval)
+    scan_interval_sec = _clamp_scan_interval(entry.options.get(CONF_SCAN_INTERVAL))
+    coordinator = EclModbusCoordinator(hass, hub, enabled_regs, scan_interval_sec)
+
+    # First refresh BEFORE platforms set up (prevents coordinator.data=None issues)
+    await coordinator.async_config_entry_first_refresh()
+
+    store["coordinator"] = coordinator
+    store["registers"] = enabled_regs
+    store["entry_title"] = entry.data.get(CONF_NAME, DEFAULT_NAME)
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
-    # Reload integration automatically when the entry is updated (options changed)
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
-
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Unload a config entry and close the Modbus client."""
-    # Close the Modbus hub (if any) to free the serial port
-    entry_store = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    store = hass.data.get(DOMAIN, {}).get(entry.entry_id, {})
+    hub = store.get("hub")
 
-    if isinstance(entry_store, dict):
-        hub = entry_store.get("hub")
-        if hub is not None:
-            try:
-                hub.close()
-            except Exception:  # noqa: BLE001
-                pass
-
-    # Unload all platforms
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+    # Close hub AFTER platforms are unloaded (safer)
+    if hub is not None:
+        try:
+            hub.close()
+        except Exception:  # noqa: BLE001
+            pass
 
     if unload_ok and DOMAIN in hass.data:
         hass.data[DOMAIN].pop(entry.entry_id, None)
@@ -50,5 +108,4 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Handle config entry updates (e.g. options changed) by reloading."""
     await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/ecl_modbus/config_flow.py
+++ b/custom_components/ecl_modbus/config_flow.py
@@ -1,34 +1,32 @@
 from __future__ import annotations
 
-"""Config flow and options flow for the ECL Modbus integration."""
+"""Config flow (UI setup) and options flow for the ECL Modbus integration.
+
+This implementation is register-driven:
+- The list of available registers lives in `registers.py`
+- Options are generated dynamically from that list
+- Sensor platform reads the same options keys (enable_<register_key>)
+"""
 
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME, CONF_PORT
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.config_entries import ConfigEntry
 
 from .const import (
     DOMAIN,
-    DEFAULT_NAME,
     DEFAULT_BAUDRATE,
+    DEFAULT_NAME,
+    DEFAULT_SCAN_INTERVAL,
     DEFAULT_SLAVE_ID,
     CONF_BAUDRATE,
+    CONF_SCAN_INTERVAL,
     CONF_SLAVE_ID,
-    CONF_ENABLE_S1,
-    CONF_ENABLE_S2,
-    CONF_ENABLE_S3,
-    CONF_ENABLE_S4,
-    CONF_ENABLE_S5,
-    CONF_ENABLE_S6,
-    CONF_ENABLE_IP_ADDRESS,
-    CONF_ENABLE_MAC_ADDRESS,
-    CONF_ENABLE_VALVE_POSITION,
-    CONF_ENABLE_HEAT_FLOW_REF,
-    CONF_ENABLE_HEAT_RETURN_REF,
 )
+from .registers import ALL_REGISTERS, option_key
 
 
 class EclModbusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -67,7 +65,12 @@ class EclModbusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 
 class EclModbusOptionsFlow(config_entries.OptionsFlow):
-    """Handle options (which sensors are enabled) for an existing entry."""
+    """Handle options for an existing entry.
+
+    Options include:
+    - Which registers should be enabled (checkbox per register)
+    - Global poll interval (scan_interval)
+    """
 
     def __init__(self, config_entry: ConfigEntry) -> None:
         self._entry = config_entry
@@ -84,42 +87,29 @@ class EclModbusOptionsFlow(config_entries.OptionsFlow):
 
         options = self._entry.options
 
-        def opt(key: str, default: bool) -> bool:
+        def opt_bool(key: str, default: bool) -> bool:
             """Helper to read a boolean option with a default."""
             return bool(options.get(key, default))
 
-        # Defaults: S3 & S4 on, others off; extra sensors off by default
-        data_schema = vol.Schema(
-            {
-                # Temperature sensors S1–S6
-                vol.Optional(CONF_ENABLE_S1, default=opt(CONF_ENABLE_S1, False)): bool,
-                vol.Optional(CONF_ENABLE_S2, default=opt(CONF_ENABLE_S2, False)): bool,
-                vol.Optional(CONF_ENABLE_S3, default=opt(CONF_ENABLE_S3, True)): bool,
-                vol.Optional(CONF_ENABLE_S4, default=opt(CONF_ENABLE_S4, True)): bool,
-                vol.Optional(CONF_ENABLE_S5, default=opt(CONF_ENABLE_S5, False)): bool,
-                vol.Optional(CONF_ENABLE_S6, default=opt(CONF_ENABLE_S6, False)): bool,
-                # Extra sensors: IP, MAC, valve position
-                vol.Optional(
-                    CONF_ENABLE_IP_ADDRESS,
-                    default=opt(CONF_ENABLE_IP_ADDRESS, False),
-                ): bool,
-                vol.Optional(
-                    CONF_ENABLE_MAC_ADDRESS,
-                    default=opt(CONF_ENABLE_MAC_ADDRESS, False),
-                ): bool,
-                vol.Optional(
-                    CONF_ENABLE_VALVE_POSITION,
-                    default=opt(CONF_ENABLE_VALVE_POSITION, False),
-                ): bool,
-                vol.Optional(
-                    CONF_ENABLE_HEAT_FLOW_REF,
-                    default=opt(CONF_ENABLE_HEAT_FLOW_REF, False),
-                ): bool,
-                vol.Optional(
-                    CONF_ENABLE_HEAT_RETURN_REF,
-                    default=opt(CONF_ENABLE_HEAT_RETURN_REF, False),
-                ): bool,
-            }
-        )
+        # Default enable behaviour:
+        # - Keep defaults conservative
+        # - S3/S4 are commonly used, so enable them by default (if no options exist)
+        default_enabled_keys = {"s3_temperature", "s4_temperature"}
 
-        return self.async_show_form(step_id="options", data_schema=data_schema)
+        schema_dict: dict[vol.Marker, object] = {}
+
+        # One checkbox per register
+        for reg in ALL_REGISTERS:
+            k = option_key(reg.key)
+            default_value = opt_bool(k, reg.key in default_enabled_keys)
+            schema_dict[vol.Optional(k, default=default_value)] = bool
+
+        # Global polling interval (seconds)
+        schema_dict[
+            vol.Optional(
+                CONF_SCAN_INTERVAL,
+                default=options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+            )
+        ] = vol.All(int, vol.Clamp(min=5, max=3600))
+
+        return self.async_show_form(step_id="options", data_schema=vol.Schema(schema_dict))

--- a/custom_components/ecl_modbus/const.py
+++ b/custom_components/ecl_modbus/const.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 """
 Constants for the ECL Modbus integration.
 
-This file contains only static constants and configuration keys.
-No runtime logic must be placed here.
+This file must contain ONLY static constants and configuration keys.
+No runtime logic, no register definitions, no enable flags.
 """
 
 # -----------------------------------------------------------------------------
@@ -12,7 +12,13 @@ No runtime logic must be placed here.
 # -----------------------------------------------------------------------------
 
 DOMAIN = "ecl_modbus"
-PLATFORMS: list[str] = ["sensor"]
+
+# Platforms provided by this integration
+PLATFORMS: list[str] = [
+    "sensor",   # Read-only registers
+    "number",   # Writable numeric registers (RW)
+    # "select", # Future: token-based RW registers (Comfort/Night/etc.)
+]
 
 # -----------------------------------------------------------------------------
 # Config flow base options
@@ -20,43 +26,9 @@ PLATFORMS: list[str] = ["sensor"]
 
 CONF_BAUDRATE = "baudrate"
 CONF_SLAVE_ID = "slave_id"
+CONF_SCAN_INTERVAL = "scan_interval"
 
 DEFAULT_NAME = "ECL Modbus"
 DEFAULT_BAUDRATE = 38400
 DEFAULT_SLAVE_ID = 5
-
-# -----------------------------------------------------------------------------
-# Sensor enable options – physical temperature sensors
-# -----------------------------------------------------------------------------
-
-CONF_ENABLE_S1 = "enable_s1"
-CONF_ENABLE_S2 = "enable_s2"
-CONF_ENABLE_S3 = "enable_s3"
-CONF_ENABLE_S4 = "enable_s4"
-CONF_ENABLE_S5 = "enable_s5"
-CONF_ENABLE_S6 = "enable_s6"
-
-# -----------------------------------------------------------------------------
-# Sensor enable options – system / network information
-# -----------------------------------------------------------------------------
-
-CONF_ENABLE_IP_ADDRESS = "enable_ip_address"
-CONF_ENABLE_MAC_ADDRESS = "enable_mac_address"
-
-# -----------------------------------------------------------------------------
-# Sensor enable options – application / heating values
-# -----------------------------------------------------------------------------
-
-# Circuit heat references (read-only)
-CONF_ENABLE_HEAT_FLOW_REF = "enable_heat_flow_ref"
-CONF_ENABLE_HEAT_WEATHER_REF = "enable_heat_weather_ref"
-
-# Circuit outputs (read-only)
-CONF_ENABLE_VALVE_POSITION = "enable_valve_position"
-
-# -----------------------------------------------------------------------------
-# Polling
-# -----------------------------------------------------------------------------
-
-CONF_SCAN_INTERVAL = "scan_interval"
 DEFAULT_SCAN_INTERVAL = 30

--- a/custom_components/ecl_modbus/const.py
+++ b/custom_components/ecl_modbus/const.py
@@ -10,7 +10,7 @@ No runtime logic.
 DOMAIN = "ecl_modbus"
 
 # Platforms we expose
-PLATFORMS: list[str] = ["sensor", "number"]
+PLATFORMS: list[str] = ["sensor", "number", "select"]
 
 # Config entry (setup)
 CONF_BAUDRATE = "baudrate"

--- a/custom_components/ecl_modbus/const.py
+++ b/custom_components/ecl_modbus/const.py
@@ -1,23 +1,34 @@
 from __future__ import annotations
 
-"""Constants for the ECL Modbus integration."""
+"""
+Constants for the ECL Modbus integration.
 
-# Domain used by Home Assistant
+This file contains only static constants and configuration keys.
+No runtime logic must be placed here.
+"""
+
+# -----------------------------------------------------------------------------
+# Integration basics
+# -----------------------------------------------------------------------------
+
 DOMAIN = "ecl_modbus"
-
-# This integration exposes only the sensor platform
 PLATFORMS: list[str] = ["sensor"]
 
-# Configuration keys (for config flow)
+# -----------------------------------------------------------------------------
+# Config flow base options
+# -----------------------------------------------------------------------------
+
 CONF_BAUDRATE = "baudrate"
 CONF_SLAVE_ID = "slave_id"
 
-# Default values
 DEFAULT_NAME = "ECL Modbus"
 DEFAULT_BAUDRATE = 38400
 DEFAULT_SLAVE_ID = 5
 
-# Options: enable/disable temperature sensors S1–S6
+# -----------------------------------------------------------------------------
+# Sensor enable options – physical temperature sensors
+# -----------------------------------------------------------------------------
+
 CONF_ENABLE_S1 = "enable_s1"
 CONF_ENABLE_S2 = "enable_s2"
 CONF_ENABLE_S3 = "enable_s3"
@@ -25,11 +36,27 @@ CONF_ENABLE_S4 = "enable_s4"
 CONF_ENABLE_S5 = "enable_s5"
 CONF_ENABLE_S6 = "enable_s6"
 
-# Options: enable/disable extra sensors
+# -----------------------------------------------------------------------------
+# Sensor enable options – system / network information
+# -----------------------------------------------------------------------------
+
 CONF_ENABLE_IP_ADDRESS = "enable_ip_address"
 CONF_ENABLE_MAC_ADDRESS = "enable_mac_address"
+
+# -----------------------------------------------------------------------------
+# Sensor enable options – application / heating values
+# -----------------------------------------------------------------------------
+
+# Circuit heat references (read-only)
+CONF_ENABLE_HEAT_FLOW_REF = "enable_heat_flow_ref"
+CONF_ENABLE_HEAT_WEATHER_REF = "enable_heat_weather_ref"
+
+# Circuit outputs (read-only)
 CONF_ENABLE_VALVE_POSITION = "enable_valve_position"
 
-# Extra temperature reference sensors
-CONF_ENABLE_HEAT_FLOW_REF = "enable_heat_flow_ref"
-CONF_ENABLE_HEAT_RETURN_REF = "enable_heat_return_ref"
+# -----------------------------------------------------------------------------
+# Polling
+# -----------------------------------------------------------------------------
+
+CONF_SCAN_INTERVAL = "scan_interval"
+DEFAULT_SCAN_INTERVAL = 30

--- a/custom_components/ecl_modbus/const.py
+++ b/custom_components/ecl_modbus/const.py
@@ -3,27 +3,16 @@ from __future__ import annotations
 """
 Constants for the ECL Modbus integration.
 
-This file must contain ONLY static constants and configuration keys.
-No runtime logic, no register definitions, no enable flags.
+Keep ONLY constants and config keys here.
+No runtime logic.
 """
-
-# -----------------------------------------------------------------------------
-# Integration basics
-# -----------------------------------------------------------------------------
 
 DOMAIN = "ecl_modbus"
 
-# Platforms provided by this integration
-PLATFORMS: list[str] = [
-    "sensor",   # Read-only registers
-    "number",   # Writable numeric registers (RW)
-    # "select", # Future: token-based RW registers (Comfort/Night/etc.)
-]
+# Platforms we expose
+PLATFORMS: list[str] = ["sensor", "number"]
 
-# -----------------------------------------------------------------------------
-# Config flow base options
-# -----------------------------------------------------------------------------
-
+# Config entry (setup)
 CONF_BAUDRATE = "baudrate"
 CONF_SLAVE_ID = "slave_id"
 CONF_SCAN_INTERVAL = "scan_interval"

--- a/custom_components/ecl_modbus/manifest.json
+++ b/custom_components/ecl_modbus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ecl_modbus",
   "name": "ECL Modbus",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "documentation": "https://github.com/nichlasrohde/ha-ecl-modbus",
   "requirements": [],
   "codeowners": ["@nichlasrohde"],

--- a/custom_components/ecl_modbus/manifest.json
+++ b/custom_components/ecl_modbus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ecl_modbus",
   "name": "ECL Modbus",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "documentation": "https://github.com/nichlasrohde/ha-ecl-modbus",
   "requirements": [],
   "codeowners": ["@nichlasrohde"],

--- a/custom_components/ecl_modbus/modbus.py
+++ b/custom_components/ecl_modbus/modbus.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+"""Shared Modbus hub + coordinator for ECL Modbus.
+
+This module contains:
+- EclModbusHub: handles serial connection + low-level read/write
+- EclModbusCoordinator: polls enabled registers on a global interval
+
+Keeping this separate avoids platform import order issues (sensor/number).
+"""
+
+import logging
+import struct
+import threading
+from datetime import timedelta
+from typing import Any
+
+from pymodbus.client import ModbusSerialClient
+from pymodbus.exceptions import ModbusIOException
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .registers import RegisterDef, RegisterType
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class EclModbusHub:
+    """Handle Modbus RTU communication with the ECL controller."""
+
+    def __init__(self, port: str, baudrate: int, slave_id: int) -> None:
+        self._port = port
+        self._baudrate = baudrate
+        self._slave_id = slave_id
+        self._client: ModbusSerialClient | None = None
+        self._lock = threading.Lock()
+
+    def _ensure_client(self) -> None:
+        if self._client is not None and self._client.connected:
+            return
+
+        _LOGGER.info(
+            "ECL Modbus: creating ModbusSerialClient on %s @ %s baud",
+            self._port,
+            self._baudrate,
+        )
+
+        if self._client is not None:
+            try:
+                self._client.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+        self._client = ModbusSerialClient(
+            port=self._port,
+            baudrate=self._baudrate,
+            parity="E",
+            stopbits=1,
+            bytesize=8,
+            timeout=2,
+        )
+
+        if not self._client.connect():
+            raise ModbusIOException(f"Could not connect to {self._port}")
+
+    def close(self) -> None:
+        if self._client is not None:
+            try:
+                self._client.close()
+            except Exception:  # noqa: BLE001
+                pass
+        self._client = None
+
+    def _read_registers(self, reg_address_manual: int, count: int) -> list[int] | None:
+        """Read holding registers (manual addresses are 1-based in Danfoss docs)."""
+        with self._lock:
+            try:
+                self._ensure_client()
+                pdu_address = reg_address_manual - 1
+                result = self._client.read_holding_registers(
+                    address=pdu_address,
+                    count=count,
+                    device_id=self._slave_id,
+                )
+            except ModbusIOException as exc:
+                _LOGGER.error("ECL Modbus: ModbusIOException reading %s: %s", reg_address_manual, exc)
+                self.close()
+                return None
+            except Exception as exc:  # noqa: BLE001
+                _LOGGER.error("ECL Modbus: unexpected error reading %s: %s", reg_address_manual, exc)
+                self.close()
+                return None
+
+        if not result or getattr(result, "isError", lambda: True)():
+            _LOGGER.warning("ECL Modbus: Modbus error/no response at %s: %s", reg_address_manual, result)
+            return None
+
+        regs = getattr(result, "registers", None)
+        if not regs:
+            _LOGGER.warning("ECL Modbus: empty register response at %s: %s", reg_address_manual, result)
+            return None
+
+        return list(regs)
+
+    def read_float(self, reg_address_manual: int) -> float | None:
+        regs = self._read_registers(reg_address_manual, count=2)
+        if regs is None:
+            return None
+        raw = (regs[0] << 16) | regs[1]
+        return struct.unpack(">f", raw.to_bytes(4, byteorder="big"))[0]
+
+    def read_int16(self, reg_address_manual: int, signed: bool = True) -> int | None:
+        regs = self._read_registers(reg_address_manual, count=1)
+        if regs is None:
+            return None
+        raw = regs[0]
+        if signed and raw > 0x7FFF:
+            raw -= 0x10000
+        return raw
+
+    def read_string(self, reg_address_manual: int, reg_count: int) -> str | None:
+        regs = self._read_registers(reg_address_manual, count=reg_count)
+        if regs is None:
+            return None
+        raw_bytes = bytearray()
+        for reg in regs:
+            raw_bytes.extend(reg.to_bytes(2, byteorder="big"))
+        text = raw_bytes.decode("ascii", errors="ignore").strip("\x00").strip()
+        return text or None
+
+    # -----------------
+    # Write operations
+    # -----------------
+
+    def write_int16(self, reg_address_manual: int, value: int) -> None:
+        """Write a single 16-bit holding register (manual addr is 1-based)."""
+        with self._lock:
+            self._ensure_client()
+            pdu_address = reg_address_manual - 1
+            result = self._client.write_register(
+                address=pdu_address,
+                value=int(value) & 0xFFFF,
+                device_id=self._slave_id,
+            )
+            if not result or getattr(result, "isError", lambda: True)():
+                raise ModbusIOException(f"Write int16 failed at {reg_address_manual}: {result}")
+
+    def write_float(self, reg_address_manual: int, value: float) -> None:
+        """Write a 32-bit float into two holding registers (big-endian)."""
+        b = struct.pack(">f", float(value))
+        hi = int.from_bytes(b[0:2], byteorder="big")
+        lo = int.from_bytes(b[2:4], byteorder="big")
+
+        with self._lock:
+            self._ensure_client()
+            pdu_address = reg_address_manual - 1
+            result = self._client.write_registers(
+                address=pdu_address,
+                values=[hi, lo],
+                device_id=self._slave_id,
+            )
+            if not result or getattr(result, "isError", lambda: True)():
+                raise ModbusIOException(f"Write float failed at {reg_address_manual}: {result}")
+
+
+class EclModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Poll enabled registers at a single global interval."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        hub: EclModbusHub,
+        registers: list[RegisterDef],
+        scan_interval_sec: int,
+    ) -> None:
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="ECL Modbus Coordinator",
+            update_interval=timedelta(seconds=scan_interval_sec),
+        )
+        self.hub = hub
+        self.registers = registers
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        def _read_all() -> dict[str, Any]:
+            data: dict[str, Any] = {}
+            for reg in self.registers:
+                if reg.reg_type == RegisterType.FLOAT:
+                    data[reg.key] = self.hub.read_float(reg.address)
+                elif reg.reg_type == RegisterType.INT16:
+                    data[reg.key] = self.hub.read_int16(reg.address, signed=reg.signed)
+                elif reg.reg_type == RegisterType.STRING16:
+                    data[reg.key] = self.hub.read_string(reg.address, reg_count=8)
+                elif reg.reg_type == RegisterType.STRING32:
+                    data[reg.key] = self.hub.read_string(reg.address, reg_count=16)
+                else:
+                    data[reg.key] = None
+            return data
+
+        try:
+            return await self.hass.async_add_executor_job(_read_all)
+        except Exception as exc:  # noqa: BLE001
+            raise UpdateFailed(f"ECL Modbus update failed: {exc}") from exc

--- a/custom_components/ecl_modbus/number.py
+++ b/custom_components/ecl_modbus/number.py
@@ -108,7 +108,20 @@ class EclModbusRegisterNumber(CoordinatorEntity, NumberEntity):
             return None
 
         scale = float(getattr(self._reg, "scale", 1.0) or 1.0)
-        return val * scale
+        value = val * scale
+
+        # --- Presentation rounding ---
+        step = getattr(self._reg, "step", None)
+        if step:
+            # Number of decimals derived from step (e.g. 0.1 -> 1, 0.01 -> 2)
+            decimals = max(0, len(str(step).split(".")[-1]))
+            return round(value, decimals)
+
+        # Sensible defaults
+        if self._reg.device_class == "temperature":
+            return round(value, 1)
+
+        return round(value, 2)
 
     async def async_set_native_value(self, value: float) -> None:
         if not getattr(self._reg, "writable", False):

--- a/custom_components/ecl_modbus/number.py
+++ b/custom_components/ecl_modbus/number.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+"""Number platform for ECL Modbus.
+
+RW registers (writable=True) should NOT be sensors.
+They are exposed as NumberEntity so users can change setpoints/overrides.
+
+Design:
+- Reuse hub + coordinator created in sensor.py (stored in hass.data[DOMAIN][entry_id]).
+- Write to Modbus, then update coordinator cache to reflect the new value immediately.
+- Optional: request a refresh after write (commented) if you want "read-back" validation.
+"""
+
+import logging
+import struct
+from dataclasses import dataclass
+from typing import Any
+
+from homeassistant.components.number import NumberEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, DEFAULT_NAME
+from .registers import RegisterDef, RegisterType
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# -----------------------------------------------------------------------------
+# Helpers: encode values for Modbus writes
+# -----------------------------------------------------------------------------
+
+def _float_to_regs_be(value: float) -> list[int]:
+    """Encode float -> 2x16-bit registers (big endian)."""
+    raw = struct.pack(">f", float(value))
+    hi = int.from_bytes(raw[0:2], byteorder="big", signed=False)
+    lo = int.from_bytes(raw[2:4], byteorder="big", signed=False)
+    return [hi, lo]
+
+
+def _coerce_step(value: float, step: float | None) -> float:
+    """Snap to step if provided."""
+    if not step:
+        return value
+    if step <= 0:
+        return value
+    # Snap to nearest step (avoid float noise)
+    snapped = round(value / step) * step
+    # Keep reasonable precision
+    return float(round(snapped, 6))
+
+
+def _clamp(value: float, min_v: float | None, max_v: float | None) -> float:
+    if min_v is not None and value < min_v:
+        return min_v
+    if max_v is not None and value > max_v:
+        return max_v
+    return value
+
+
+# -----------------------------------------------------------------------------
+# Modbus hub "interface" we expect (provided by sensor.py)
+# -----------------------------------------------------------------------------
+
+@dataclass(frozen=True, slots=True)
+class _HubWriteAPI:
+    """Document the expected hub API (duck-typed)."""
+    # This is only for readability; we don't instantiate this.
+    pass
+
+
+# -----------------------------------------------------------------------------
+# Entity
+# -----------------------------------------------------------------------------
+
+class EclModbusRegisterNumber(CoordinatorEntity, NumberEntity):
+    """Number entity for one writable register."""
+
+    _attr_mode = "box"  # nice UX (also supports slider if you prefer)
+
+    def __init__(self, coordinator, entry_title: str, hub, reg: RegisterDef) -> None:
+        super().__init__(coordinator)
+        self._hub = hub
+        self._reg = reg
+
+        self._attr_name = f"{entry_title} {reg.name}"
+        self._attr_unique_id = f"{DOMAIN}_{reg.key}"
+
+        # Presentation
+        self._attr_native_unit_of_measurement = reg.unit
+        self._attr_device_class = reg.device_class
+        self._attr_icon = reg.icon
+
+        # Limits (from RegisterDef)
+        self._attr_native_min_value = float(reg.min_value) if getattr(reg, "min_value", None) is not None else None
+        self._attr_native_max_value = float(reg.max_value) if getattr(reg, "max_value", None) is not None else None
+        self._attr_native_step = float(reg.step) if getattr(reg, "step", None) is not None else None
+
+        # Extra attrs for debugging
+        self._attr_extra_state_attributes = {
+            "ecl_modbus_register": reg.address,
+            "ecl_modbus_type": reg.reg_type.value,
+            "ecl_modbus_writable": True,
+            "ecl_modbus_scale": getattr(reg, "scale", 1.0),
+        }
+
+    @property
+    def device_info(self) -> dict:
+        """Group all entities under a single ECL device."""
+        return {
+            "identifiers": {(DOMAIN, "ecl_modbus")},
+            "name": "ECL Modbus",
+            "manufacturer": "Danfoss",
+            "model": "ECL 120/220",
+        }
+
+    @property
+    def native_value(self) -> float | None:
+        """Expose the latest value from the coordinator cache."""
+        raw = self.coordinator.data.get(self._reg.key)
+        if raw is None:
+            return None
+
+        try:
+            # coordinator stores decoded numeric (float/int) already.
+            val = float(raw)
+        except (TypeError, ValueError):
+            return None
+
+        # Apply scaling for display (same as sensors)
+        scale = float(getattr(self._reg, "scale", 1.0) or 1.0)
+        return val * scale
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Write new value to Modbus and update local cache."""
+        if not getattr(self._reg, "writable", False):
+            raise ValueError("Register is not writable")
+
+        # Enforce min/max/step in HA side (controller might enforce too)
+        step = self._attr_native_step
+        min_v = self._attr_native_min_value
+        max_v = self._attr_native_max_value
+
+        value = _coerce_step(float(value), float(step) if step else None)
+        value = _clamp(value, float(min_v) if min_v is not None else None, float(max_v) if max_v is not None else None)
+
+        # Convert from displayed unit -> raw register value (undo scaling)
+        scale = float(getattr(self._reg, "scale", 1.0) or 1.0)
+        raw_to_write = value / scale if scale != 0 else value
+
+        # Perform write in executor (pymodbus is blocking)
+        await self.hass.async_add_executor_job(self._write_register_value, raw_to_write)
+
+        # Update coordinator cache immediately so UI updates instantly
+        self.coordinator.data[self._reg.key] = raw_to_write  # store RAW (unscaled) like reader does
+        self.async_write_ha_state()
+
+        # Optional: request a refresh to validate read-back (can be noisy on RS485)
+        # await self.coordinator.async_request_refresh()
+
+    def _write_register_value(self, raw_value: float) -> None:
+        """Blocking write to Modbus (runs in executor)."""
+        # Access manual address in docs (1-based)
+        pdu_address = self._reg.address - 1
+
+        # Ensure hub has a connected client
+        self._hub._ensure_client()  # noqa: SLF001 (we control hub; keeps code simple)
+
+        try:
+            if self._reg.reg_type == RegisterType.FLOAT:
+                regs = _float_to_regs_be(float(raw_value))
+                result = self._hub._client.write_registers(  # noqa: SLF001
+                    address=pdu_address,
+                    values=regs,
+                    device_id=self._hub._slave_id,  # noqa: SLF001
+                )
+            elif self._reg.reg_type == RegisterType.INT16:
+                # INT16 write: if signed and negative -> two's complement
+                val = int(round(raw_value))
+                if getattr(self._reg, "signed", True) and val < 0:
+                    val = (val + 0x10000) & 0xFFFF
+
+                result = self._hub._client.write_register(  # noqa: SLF001
+                    address=pdu_address,
+                    value=val,
+                    device_id=self._hub._slave_id,  # noqa: SLF001
+                )
+            else:
+                raise ValueError(f"Unsupported writable type: {self._reg.reg_type}")
+
+            if not result or getattr(result, "isError", lambda: True)():
+                raise ModbusWriteError(f"Modbus write failed: {result}")
+
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.error(
+                "ECL Modbus: write failed for %s (addr=%s): %s",
+                self._reg.key,
+                self._reg.address,
+                exc,
+            )
+            # Force reconnect next time if serial is upset
+            try:
+                self._hub.close()
+            except Exception:  # noqa: BLE001
+                pass
+            raise
+
+
+class ModbusWriteError(Exception):
+    """Raised when a Modbus write fails."""
+
+
+# -----------------------------------------------------------------------------
+# Platform setup
+# -----------------------------------------------------------------------------
+
+def _entry_store(hass: HomeAssistant, entry: ConfigEntry) -> dict[str, Any]:
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    store = domain_data.get(entry.entry_id)
+    if not isinstance(store, dict):
+        store = {}
+        domain_data[entry.entry_id] = store
+    return store
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Number entities for writable registers."""
+    store = _entry_store(hass, entry)
+
+    coordinator = store.get("coordinator")
+    hub = store.get("hub")
+    regs: list[RegisterDef] = store.get("registers", [])
+
+    if coordinator is None or hub is None:
+        _LOGGER.error("ECL Modbus: number platform missing coordinator/hub (setup order issue)")
+        return
+
+    entry_title = entry.data.get(CONF_NAME, DEFAULT_NAME)
+
+    # Only RW regs that are numeric
+    rw_regs = [
+        r for r in regs
+        if getattr(r, "writable", False)
+        and r.reg_type in (RegisterType.FLOAT, RegisterType.INT16)
+    ]
+
+    entities: list[NumberEntity] = [
+        EclModbusRegisterNumber(coordinator, entry_title, hub, reg) for reg in rw_regs
+    ]
+
+    async_add_entities(entities, update_before_add=False)

--- a/custom_components/ecl_modbus/number.py
+++ b/custom_components/ecl_modbus/number.py
@@ -203,6 +203,7 @@ async def async_setup_entry(
         r for r in regs
         if getattr(r, "writable", False)
         and r.reg_type in (RegisterType.FLOAT, RegisterType.INT16)
+        and not getattr(r, "value_map", None)  # <-- VIGTIG
     ]
 
     async_add_entities(

--- a/custom_components/ecl_modbus/number.py
+++ b/custom_components/ecl_modbus/number.py
@@ -2,18 +2,15 @@ from __future__ import annotations
 
 """Number platform for ECL Modbus.
 
-RW registers (writable=True) should NOT be sensors.
-They are exposed as NumberEntity so users can change setpoints/overrides.
+Writable (RW) registers are exposed as NumberEntity so users can change setpoints.
 
 Design:
-- Reuse hub + coordinator created in sensor.py (stored in hass.data[DOMAIN][entry_id]).
-- Write to Modbus, then update coordinator cache to reflect the new value immediately.
-- Optional: request a refresh after write (commented) if you want "read-back" validation.
+- Hub + coordinator are created in __init__.py and stored in hass.data[DOMAIN][entry_id].
+- Write uses hub.write_float / hub.write_int16 (no private attributes).
+- After write, we update local coordinator cache (if available) and optionally refresh.
 """
 
 import logging
-import struct
-from dataclasses import dataclass
 from typing import Any
 
 from homeassistant.components.number import NumberEntity
@@ -29,27 +26,10 @@ from .registers import RegisterDef, RegisterType
 _LOGGER = logging.getLogger(__name__)
 
 
-# -----------------------------------------------------------------------------
-# Helpers: encode values for Modbus writes
-# -----------------------------------------------------------------------------
-
-def _float_to_regs_be(value: float) -> list[int]:
-    """Encode float -> 2x16-bit registers (big endian)."""
-    raw = struct.pack(">f", float(value))
-    hi = int.from_bytes(raw[0:2], byteorder="big", signed=False)
-    lo = int.from_bytes(raw[2:4], byteorder="big", signed=False)
-    return [hi, lo]
-
-
 def _coerce_step(value: float, step: float | None) -> float:
-    """Snap to step if provided."""
-    if not step:
+    if not step or step <= 0:
         return value
-    if step <= 0:
-        return value
-    # Snap to nearest step (avoid float noise)
     snapped = round(value / step) * step
-    # Keep reasonable precision
     return float(round(snapped, 6))
 
 
@@ -61,162 +41,6 @@ def _clamp(value: float, min_v: float | None, max_v: float | None) -> float:
     return value
 
 
-# -----------------------------------------------------------------------------
-# Modbus hub "interface" we expect (provided by sensor.py)
-# -----------------------------------------------------------------------------
-
-@dataclass(frozen=True, slots=True)
-class _HubWriteAPI:
-    """Document the expected hub API (duck-typed)."""
-    # This is only for readability; we don't instantiate this.
-    pass
-
-
-# -----------------------------------------------------------------------------
-# Entity
-# -----------------------------------------------------------------------------
-
-class EclModbusRegisterNumber(CoordinatorEntity, NumberEntity):
-    """Number entity for one writable register."""
-
-    _attr_mode = "box"  # nice UX (also supports slider if you prefer)
-
-    def __init__(self, coordinator, entry_title: str, hub, reg: RegisterDef) -> None:
-        super().__init__(coordinator)
-        self._hub = hub
-        self._reg = reg
-
-        self._attr_name = f"{entry_title} {reg.name}"
-        self._attr_unique_id = f"{DOMAIN}_{reg.key}"
-
-        # Presentation
-        self._attr_native_unit_of_measurement = reg.unit
-        self._attr_device_class = reg.device_class
-        self._attr_icon = reg.icon
-
-        # Limits (from RegisterDef)
-        self._attr_native_min_value = float(reg.min_value) if getattr(reg, "min_value", None) is not None else None
-        self._attr_native_max_value = float(reg.max_value) if getattr(reg, "max_value", None) is not None else None
-        self._attr_native_step = float(reg.step) if getattr(reg, "step", None) is not None else None
-
-        # Extra attrs for debugging
-        self._attr_extra_state_attributes = {
-            "ecl_modbus_register": reg.address,
-            "ecl_modbus_type": reg.reg_type.value,
-            "ecl_modbus_writable": True,
-            "ecl_modbus_scale": getattr(reg, "scale", 1.0),
-        }
-
-    @property
-    def device_info(self) -> dict:
-        """Group all entities under a single ECL device."""
-        return {
-            "identifiers": {(DOMAIN, "ecl_modbus")},
-            "name": "ECL Modbus",
-            "manufacturer": "Danfoss",
-            "model": "ECL 120/220",
-        }
-
-    @property
-    def native_value(self) -> float | None:
-        """Expose the latest value from the coordinator cache."""
-        raw = self.coordinator.data.get(self._reg.key)
-        if raw is None:
-            return None
-
-        try:
-            # coordinator stores decoded numeric (float/int) already.
-            val = float(raw)
-        except (TypeError, ValueError):
-            return None
-
-        # Apply scaling for display (same as sensors)
-        scale = float(getattr(self._reg, "scale", 1.0) or 1.0)
-        return val * scale
-
-    async def async_set_native_value(self, value: float) -> None:
-        """Write new value to Modbus and update local cache."""
-        if not getattr(self._reg, "writable", False):
-            raise ValueError("Register is not writable")
-
-        # Enforce min/max/step in HA side (controller might enforce too)
-        step = self._attr_native_step
-        min_v = self._attr_native_min_value
-        max_v = self._attr_native_max_value
-
-        value = _coerce_step(float(value), float(step) if step else None)
-        value = _clamp(value, float(min_v) if min_v is not None else None, float(max_v) if max_v is not None else None)
-
-        # Convert from displayed unit -> raw register value (undo scaling)
-        scale = float(getattr(self._reg, "scale", 1.0) or 1.0)
-        raw_to_write = value / scale if scale != 0 else value
-
-        # Perform write in executor (pymodbus is blocking)
-        await self.hass.async_add_executor_job(self._write_register_value, raw_to_write)
-
-        # Update coordinator cache immediately so UI updates instantly
-        self.coordinator.data[self._reg.key] = raw_to_write  # store RAW (unscaled) like reader does
-        self.async_write_ha_state()
-
-        # Optional: request a refresh to validate read-back (can be noisy on RS485)
-        # await self.coordinator.async_request_refresh()
-
-    def _write_register_value(self, raw_value: float) -> None:
-        """Blocking write to Modbus (runs in executor)."""
-        # Access manual address in docs (1-based)
-        pdu_address = self._reg.address - 1
-
-        # Ensure hub has a connected client
-        self._hub._ensure_client()  # noqa: SLF001 (we control hub; keeps code simple)
-
-        try:
-            if self._reg.reg_type == RegisterType.FLOAT:
-                regs = _float_to_regs_be(float(raw_value))
-                result = self._hub._client.write_registers(  # noqa: SLF001
-                    address=pdu_address,
-                    values=regs,
-                    device_id=self._hub._slave_id,  # noqa: SLF001
-                )
-            elif self._reg.reg_type == RegisterType.INT16:
-                # INT16 write: if signed and negative -> two's complement
-                val = int(round(raw_value))
-                if getattr(self._reg, "signed", True) and val < 0:
-                    val = (val + 0x10000) & 0xFFFF
-
-                result = self._hub._client.write_register(  # noqa: SLF001
-                    address=pdu_address,
-                    value=val,
-                    device_id=self._hub._slave_id,  # noqa: SLF001
-                )
-            else:
-                raise ValueError(f"Unsupported writable type: {self._reg.reg_type}")
-
-            if not result or getattr(result, "isError", lambda: True)():
-                raise ModbusWriteError(f"Modbus write failed: {result}")
-
-        except Exception as exc:  # noqa: BLE001
-            _LOGGER.error(
-                "ECL Modbus: write failed for %s (addr=%s): %s",
-                self._reg.key,
-                self._reg.address,
-                exc,
-            )
-            # Force reconnect next time if serial is upset
-            try:
-                self._hub.close()
-            except Exception:  # noqa: BLE001
-                pass
-            raise
-
-
-class ModbusWriteError(Exception):
-    """Raised when a Modbus write fails."""
-
-
-# -----------------------------------------------------------------------------
-# Platform setup
-# -----------------------------------------------------------------------------
-
 def _entry_store(hass: HomeAssistant, entry: ConfigEntry) -> dict[str, Any]:
     domain_data = hass.data.setdefault(DOMAIN, {})
     store = domain_data.get(entry.entry_id)
@@ -226,12 +50,130 @@ def _entry_store(hass: HomeAssistant, entry: ConfigEntry) -> dict[str, Any]:
     return store
 
 
+class EclModbusRegisterNumber(CoordinatorEntity, NumberEntity):
+    """Number entity for one writable register."""
+
+    _attr_mode = "box"
+
+    def __init__(self, coordinator, entry_title: str, hub, reg: RegisterDef) -> None:
+        super().__init__(coordinator)
+        self._hub = hub
+        self._reg = reg
+
+        self._attr_name = f"{entry_title} {reg.name}"
+        self._attr_unique_id = f"{DOMAIN}_{reg.key}"
+
+        self._attr_native_unit_of_measurement = reg.unit
+        self._attr_device_class = reg.device_class
+        self._attr_icon = reg.icon
+
+        self._attr_native_min_value = (
+            float(reg.min_value) if getattr(reg, "min_value", None) is not None else None
+        )
+        self._attr_native_max_value = (
+            float(reg.max_value) if getattr(reg, "max_value", None) is not None else None
+        )
+        self._attr_native_step = (
+            float(reg.step) if getattr(reg, "step", None) is not None else None
+        )
+
+        self._attr_extra_state_attributes = {
+            "ecl_modbus_register": reg.address,
+            "ecl_modbus_type": reg.reg_type.value,
+            "ecl_modbus_writable": True,
+            "ecl_modbus_scale": getattr(reg, "scale", 1.0),
+        }
+
+    @property
+    def device_info(self) -> dict:
+        return {
+            "identifiers": {(DOMAIN, "ecl_modbus")},
+            "name": "ECL Modbus",
+            "manufacturer": "Danfoss",
+            "model": "ECL 120/220",
+        }
+
+    @property
+    def native_value(self) -> float | None:
+        if not self.coordinator.data:
+            return None
+
+        raw = self.coordinator.data.get(self._reg.key)
+        if raw is None:
+            return None
+
+        try:
+            val = float(raw)
+        except (TypeError, ValueError):
+            return None
+
+        scale = float(getattr(self._reg, "scale", 1.0) or 1.0)
+        return val * scale
+
+    async def async_set_native_value(self, value: float) -> None:
+        if not getattr(self._reg, "writable", False):
+            raise ValueError("Register is not writable")
+
+        # Enforce HA-side min/max/step
+        step = self._attr_native_step
+        min_v = self._attr_native_min_value
+        max_v = self._attr_native_max_value
+
+        value = _coerce_step(float(value), float(step) if step else None)
+        value = _clamp(
+            value,
+            float(min_v) if min_v is not None else None,
+            float(max_v) if max_v is not None else None,
+        )
+
+        # Undo scaling for raw write
+        scale = float(getattr(self._reg, "scale", 1.0) or 1.0)
+        raw_to_write = value / scale if scale != 0 else value
+
+        # Blocking write in executor
+        await self.hass.async_add_executor_job(self._write_register_value, raw_to_write)
+
+        # Update coordinator cache immediately if possible
+        if self.coordinator.data is None:
+            # Prevent NoneType issues during startup edge cases
+            self.coordinator.data = {}
+
+        self.coordinator.data[self._reg.key] = raw_to_write
+        self.async_write_ha_state()
+
+        # Optional but recommended: read-back validation
+        # If RS485 gets noisy, you can comment this out.
+        await self.coordinator.async_request_refresh()
+
+    def _write_register_value(self, raw_value: float) -> None:
+        """Blocking write (runs in executor)."""
+        try:
+            if self._reg.reg_type == RegisterType.FLOAT:
+                self._hub.write_float(self._reg.address, float(raw_value))
+            elif self._reg.reg_type == RegisterType.INT16:
+                self._hub.write_int16(self._reg.address, int(round(raw_value)))
+            else:
+                raise ValueError(f"Unsupported writable type: {self._reg.reg_type}")
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.error(
+                "ECL Modbus: write failed for %s (addr=%s): %s",
+                self._reg.key,
+                self._reg.address,
+                exc,
+            )
+            # Force reconnect next time
+            try:
+                self._hub.close()
+            except Exception:  # noqa: BLE001
+                pass
+            raise
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Number entities for writable registers."""
     store = _entry_store(hass, entry)
 
     coordinator = store.get("coordinator")
@@ -244,15 +186,13 @@ async def async_setup_entry(
 
     entry_title = entry.data.get(CONF_NAME, DEFAULT_NAME)
 
-    # Only RW regs that are numeric
     rw_regs = [
         r for r in regs
         if getattr(r, "writable", False)
         and r.reg_type in (RegisterType.FLOAT, RegisterType.INT16)
     ]
 
-    entities: list[NumberEntity] = [
-        EclModbusRegisterNumber(coordinator, entry_title, hub, reg) for reg in rw_regs
-    ]
-
-    async_add_entities(entities, update_before_add=False)
+    async_add_entities(
+        [EclModbusRegisterNumber(coordinator, entry_title, hub, r) for r in rw_regs],
+        update_before_add=False,
+    )

--- a/custom_components/ecl_modbus/registers.py
+++ b/custom_components/ecl_modbus/registers.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+"""Register definitions for the ECL Modbus integration.
+
+Goal:
+- Keep ALL register metadata in one place (address, type, unit, scaling, etc.)
+- Make it easy to add new registers by adding a single entry to a list.
+
+Notes:
+- ECL Modbus "manual addresses" in Danfoss docs are typically 1-based (PNU-style).
+- pymodbus read_holding_registers() uses 0-based addressing, so you usually read (address - 1).
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Final
+
+
+class RegisterType(str, Enum):
+    """How a register value should be decoded."""
+    FLOAT = "float"          # 2 x 16-bit registers -> IEEE754 float (big-endian)
+    INT16 = "int16"          # 1 x 16-bit register -> signed/unsigned int
+    STRING16 = "string16"    # 16 chars (typically 8 registers) - adjust decoder later
+    STRING32 = "string32"    # 32 chars (typically 16 registers) - adjust decoder later
+
+
+@dataclass(frozen=True, slots=True)
+class RegisterDef:
+    """Definition of one readable register/point."""
+    key: str                 # Stable internal key (also good for unique_id suffix)
+    name: str                # Human friendly name shown in Home Assistant
+    address: int             # Manual register address from Danfoss documentation
+    reg_type: RegisterType
+
+    # Optional presentation metadata
+    unit: str | None = None
+    device_class: str | None = None
+    state_class: str | None = "measurement"
+    icon: str | None = None
+
+    # Optional value handling
+    scale: float = 1.0       # Apply after decoding (e.g., int16 * 0.1)
+    signed: bool = True      # Only relevant for INT16
+
+
+# -----------------------------------------------------------------------------
+# Core temperature sensors (S1–S6)
+# -----------------------------------------------------------------------------
+REG_SENSORS: Final[list[RegisterDef]] = [
+    RegisterDef(
+        key="s1_temperature",
+        name="S1 temperature",
+        address=4000,
+        reg_type=RegisterType.FLOAT,
+        unit="°C",
+        device_class="temperature",
+        state_class="measurement",
+    ),
+    RegisterDef(
+        key="s2_temperature",
+        name="S2 temperature",
+        address=4010,
+        reg_type=RegisterType.FLOAT,
+        unit="°C",
+        device_class="temperature",
+        state_class="measurement",
+    ),
+    RegisterDef(
+        key="s3_temperature",
+        name="S3 temperature",
+        address=4020,
+        reg_type=RegisterType.FLOAT,
+        unit="°C",
+        device_class="temperature",
+        state_class="measurement",
+    ),
+    RegisterDef(
+        key="s4_temperature",
+        name="S4 temperature",
+        address=4030,
+        reg_type=RegisterType.FLOAT,
+        unit="°C",
+        device_class="temperature",
+        state_class="measurement",
+    ),
+    RegisterDef(
+        key="s5_temperature",
+        name="S5 temperature",
+        address=4040,
+        reg_type=RegisterType.FLOAT,
+        unit="°C",
+        device_class="temperature",
+        state_class="measurement",
+    ),
+    RegisterDef(
+        key="s6_temperature",
+        name="S6 temperature",
+        address=4050,
+        reg_type=RegisterType.FLOAT,
+        unit="°C",
+        device_class="temperature",
+        state_class="measurement",
+    ),
+]
+
+# -----------------------------------------------------------------------------
+# Extra diagnostics / info
+# -----------------------------------------------------------------------------
+REG_DIAGNOSTICS: Final[list[RegisterDef]] = [
+    RegisterDef(
+        key="ethernet_ip_address",
+        name="Ethernet IP address",
+        address=2100,
+        reg_type=RegisterType.STRING16,
+        state_class=None,
+        icon="mdi:ip-network",
+    ),
+    RegisterDef(
+        key="ethernet_mac_address",
+        name="Ethernet MAC address",
+        address=2110,
+        reg_type=RegisterType.STRING32,
+        state_class=None,
+        icon="mdi:lan",
+    ),
+]
+
+# -----------------------------------------------------------------------------
+# Extra calculated / control-related sensors
+# -----------------------------------------------------------------------------
+REG_EXTRAS: Final[list[RegisterDef]] = [
+    RegisterDef(
+        key="valve_position",
+        name="Valve position",
+        address=21700,
+        reg_type=RegisterType.FLOAT,
+        unit="%",
+        device_class=None,
+        state_class="measurement",
+        icon="mdi:valve",
+    ),
+    RegisterDef(
+        key="heat_flow_reference",
+        name="Heat flow temperature reference",
+        address=21200,
+        reg_type=RegisterType.FLOAT,
+        unit="°C",
+        device_class="temperature",
+        state_class="measurement",
+    ),
+    RegisterDef(
+        key="heat_weather_comp_reference",
+        name="Heat weather compensated reference",
+        address=21206,
+        reg_type=RegisterType.FLOAT,
+        unit="°C",
+        device_class="temperature",
+        state_class="measurement",
+    ),
+]
+
+# -----------------------------------------------------------------------------
+# Single list of all registers we *can* expose.
+# The integration can later decide which ones to enable via options.
+# -----------------------------------------------------------------------------
+
+ALL_REGISTERS: Final[list[RegisterDef]] = [
+    *REG_SENSORS,
+    *REG_DIAGNOSTICS,
+    *REG_EXTRAS,
+]
+
+
+def option_key(reg_key: str) -> str:
+    """Return the config entry options key used to enable/disable a register.
+
+    We keep this in one place to ensure `config_flow.py` and `sensor.py`
+    always agree on the exact options key naming.
+    """
+    return f"enable_{reg_key}"

--- a/custom_components/ecl_modbus/registers.py
+++ b/custom_components/ecl_modbus/registers.py
@@ -192,6 +192,33 @@ REG_EXTRAS: Final[list[RegisterDef]] = [
         max_value=150,
         step=0.1,
     ),
+    RegisterDef(
+        key="operation_mode",
+        name="Operation mode",
+        address=21000,
+        reg_type=RegisterType.INT16,
+        signed=False,
+        writable=True,
+        value_map={
+            0: "Automatic",
+            1: "Comfort",
+            2: "Saving",
+            3: "Frost protection",
+        },
+    ),
+    RegisterDef(
+        key="operation_status",
+        name="Operation status",
+        address=21001,
+        reg_type=RegisterType.INT16,
+        signed=False,
+        writable=False,
+        value_map={
+            0: "Comfort",
+            1: "Saving",
+            2: "Frost protection",
+        },
+    ),
 ]
 
 # -----------------------------------------------------------------------------

--- a/custom_components/ecl_modbus/registers.py
+++ b/custom_components/ecl_modbus/registers.py
@@ -157,6 +157,16 @@ REG_EXTRAS: Final[list[RegisterDef]] = [
         device_class="temperature",
         state_class="measurement",
     ),
+    RegisterDef(
+        key="heat_return_temperature_reference",
+        name="Heat return temperature reference",
+        address=21210,
+        reg_type=RegisterType.FLOAT,
+        unit="°C",
+        device_class="temperature",
+        state_class="measurement",
+        icon="mdi:thermometer-water",
+    ),
 ]
 
 # -----------------------------------------------------------------------------

--- a/custom_components/ecl_modbus/registers.py
+++ b/custom_components/ecl_modbus/registers.py
@@ -190,7 +190,7 @@ REG_EXTRAS: Final[list[RegisterDef]] = [
         writable=True,
         min_value=5,
         max_value=150,
-        step=0.5,
+        step=0.1,
     ),
 ]
 

--- a/custom_components/ecl_modbus/select.py
+++ b/custom_components/ecl_modbus/select.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+"""Select platform for ECL Modbus.
+
+Token/enum registers (e.g. 0=Auto, 1=Comfort, 2=Saving...) should be exposed
+as SelectEntity so users can choose a mode from a dropdown.
+
+Design:
+- Reuse hub + coordinator created in __init__.py (stored in hass.data[DOMAIN][entry_id]).
+- Write to Modbus, then update coordinator cache so UI updates immediately.
+"""
+
+import logging
+from typing import Any
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, DEFAULT_NAME
+from .registers import RegisterDef, RegisterType
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _entry_store(hass: HomeAssistant, entry: ConfigEntry) -> dict[str, Any]:
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    store = domain_data.get(entry.entry_id)
+    if not isinstance(store, dict):
+        store = {}
+        domain_data[entry.entry_id] = store
+    return store
+
+
+class ModbusWriteError(Exception):
+    """Raised when a Modbus write fails."""
+
+
+class EclModbusRegisterSelect(CoordinatorEntity, SelectEntity):
+    """Select entity for one token/enum register."""
+
+    def __init__(self, coordinator, entry_title: str, hub, reg: RegisterDef) -> None:
+        super().__init__(coordinator)
+        self._hub = hub
+        self._reg = reg
+
+        self._attr_name = f"{entry_title} {reg.name}"
+        self._attr_unique_id = f"{DOMAIN}_{reg.key}"
+
+        self._attr_icon = reg.icon
+
+        # Expect reg.value_map: Mapping[int, str]
+        self._options_map: dict[int, str] = dict(getattr(reg, "value_map", {}) or {})
+        self._reverse_map: dict[str, int] = {label: code for code, label in self._options_map.items()}
+
+        # HA expects list[str]
+        self._attr_options = [self._options_map[k] for k in sorted(self._options_map)]
+
+        self._attr_extra_state_attributes = {
+            "ecl_modbus_register": reg.address,
+            "ecl_modbus_type": reg.reg_type.value,
+            "ecl_modbus_writable": True,
+        }
+
+    @property
+    def device_info(self) -> dict:
+        return {
+            "identifiers": {(DOMAIN, "ecl_modbus")},
+            "name": "ECL Modbus",
+            "manufacturer": "Danfoss",
+            "model": "ECL 120/220",
+        }
+
+    @property
+    def current_option(self) -> str | None:
+        """Return current option label from coordinator cache."""
+        if not self.coordinator.data:
+            return None
+
+        raw = self.coordinator.data.get(self._reg.key)
+        if raw is None:
+            return None
+
+        try:
+            code = int(raw)
+        except (TypeError, ValueError):
+            return None
+
+        return self._options_map.get(code)
+
+    async def async_select_option(self, option: str) -> None:
+        """Write selected option to Modbus and update local cache."""
+        if option not in self._reverse_map:
+            raise ValueError(f"Unknown option: {option}")
+
+        if not getattr(self._reg, "writable", False):
+            raise ValueError("Register is not writable")
+
+        code = int(self._reverse_map[option])
+
+        await self.hass.async_add_executor_job(self._write_register_value, code)
+
+        # Update coordinator cache immediately (store RAW like reader does)
+        if self.coordinator.data is not None:
+            self.coordinator.data[self._reg.key] = code
+
+        self.async_write_ha_state()
+        # Optional validation refresh:
+        # await self.coordinator.async_request_refresh()
+
+    def _write_register_value(self, code: int) -> None:
+        """Blocking Modbus write (runs in executor)."""
+        pdu_address = self._reg.address - 1
+
+        # Ensure hub has a connected client
+        self._hub._ensure_client()  # noqa: SLF001
+
+        try:
+            # Token registers are typically one 16-bit value
+            # Use write_register for INT16/UINT16 style registers
+            if self._reg.reg_type not in (RegisterType.INT16,):
+                # If you later add RegisterType.UINT16, include it here.
+                _LOGGER.warning(
+                    "ECL Modbus: select write on non-INT16 reg_type (%s) for %s",
+                    self._reg.reg_type,
+                    self._reg.key,
+                )
+
+            result = self._hub._client.write_register(  # noqa: SLF001
+                address=pdu_address,
+                value=int(code) & 0xFFFF,
+                device_id=self._hub._slave_id,  # noqa: SLF001
+            )
+
+            if not result or getattr(result, "isError", lambda: True)():
+                raise ModbusWriteError(f"Modbus write failed: {result}")
+
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.error(
+                "ECL Modbus: write failed for %s (addr=%s): %s",
+                self._reg.key,
+                self._reg.address,
+                exc,
+            )
+            try:
+                self._hub.close()
+            except Exception:  # noqa: BLE001
+                pass
+            raise
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Select entities for token/enum registers."""
+    store = _entry_store(hass, entry)
+
+    coordinator = store.get("coordinator")
+    hub = store.get("hub")
+    regs: list[RegisterDef] = store.get("registers", [])
+
+    if coordinator is None or hub is None:
+        _LOGGER.error("ECL Modbus: select platform missing coordinator/hub (setup order issue)")
+        return
+
+    entry_title = entry.data.get(CONF_NAME, DEFAULT_NAME)
+
+    select_regs = [
+        r for r in regs
+        if getattr(r, "writable", False)
+        and getattr(r, "value_map", None)  # must have token map
+    ]
+
+    entities: list[SelectEntity] = [
+        EclModbusRegisterSelect(coordinator, entry_title, hub, reg) for reg in select_regs
+    ]
+
+    async_add_entities(entities, update_before_add=False)

--- a/custom_components/ecl_modbus/sensor.py
+++ b/custom_components/ecl_modbus/sensor.py
@@ -1,295 +1,40 @@
 from __future__ import annotations
 
-"""Sensor platform for the ECL Modbus integration.
-
-Built around one register definition list (registers.py).
-
-Important design choices:
-- One DataUpdateCoordinator polls ALL enabled registers at a single global interval.
-  This improves RS485 stability and prevents serial port locking issues.
-- Read/write (RW) registers are NOT exposed as sensors. They will be exposed as
-  Number/Select entities in separate platforms (number.py / select.py).
-"""
-
 import logging
-import struct
-import threading
-from datetime import timedelta
 from typing import Any
-
-from pymodbus.client import ModbusSerialClient
-from pymodbus.exceptions import ModbusIOException
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-    UpdateFailed,
-)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import (
-    DOMAIN,
-    DEFAULT_BAUDRATE,
-    DEFAULT_NAME,
-    DEFAULT_SCAN_INTERVAL,
-    DEFAULT_SLAVE_ID,
-    CONF_BAUDRATE,
-    CONF_SCAN_INTERVAL,
-    CONF_SLAVE_ID,
-)
-from .registers import ALL_REGISTERS, RegisterDef, RegisterType, option_key
+from .const import DOMAIN
+from .registers import RegisterDef, RegisterType
 
 _LOGGER = logging.getLogger(__name__)
 
 
-# -----------------------------------------------------------------------------
-# Modbus hub (serial client + low level readers)
-# -----------------------------------------------------------------------------
+class EclModbusRegisterSensor(CoordinatorEntity, SensorEntity):
+    """Generic sensor exposing one read-only register."""
 
-class EclModbusHub:
-    """Handle Modbus communication with the ECL controller."""
-
-    def __init__(self, port: str, baudrate: int, slave_id: int) -> None:
-        self._port = port
-        self._baudrate = baudrate
-        self._slave_id = slave_id
-        self._client: ModbusSerialClient | None = None
-        self._lock = threading.Lock()
-
-    def _ensure_client(self) -> None:
-        """Ensure that the Modbus client is initialized and connected."""
-        if self._client is not None and self._client.connected:
-            return
-
-        _LOGGER.info(
-            "ECL Modbus: creating ModbusSerialClient on %s @ %s baud",
-            self._port,
-            self._baudrate,
-        )
-
-        # Close any previous client
-        if self._client is not None:
-            try:
-                self._client.close()
-            except Exception:  # noqa: BLE001
-                pass
-
-        self._client = ModbusSerialClient(
-            port=self._port,
-            baudrate=self._baudrate,
-            parity="E",  # ECL default: Even parity
-            stopbits=1,
-            bytesize=8,
-            timeout=2,
-        )
-
-        if not self._client.connect():
-            raise ModbusIOException(f"Could not connect to {self._port}")
-
-    def close(self) -> None:
-        """Explicitly close the Modbus client."""
-        if self._client is not None:
-            try:
-                self._client.close()
-            except Exception:  # noqa: BLE001
-                pass
-        self._client = None
-
-    def _read_registers(self, reg_address_manual: int, count: int) -> list[int] | None:
-        """Read raw holding registers.
-
-        ECL documentation uses 1-based manual addresses.
-        pymodbus expects 0-based PDU addresses.
-        """
-        with self._lock:
-            try:
-                self._ensure_client()
-                pdu_address = reg_address_manual - 1
-                result = self._client.read_holding_registers(
-                    address=pdu_address,
-                    count=count,
-                    device_id=self._slave_id,
-                )
-            except ModbusIOException as exc:
-                _LOGGER.error(
-                    "ECL Modbus: ModbusIOException reading %s: %s",
-                    reg_address_manual,
-                    exc,
-                )
-                # Force reconnect next time
-                self.close()
-                return None
-            except Exception as exc:  # noqa: BLE001
-                _LOGGER.error(
-                    "ECL Modbus: unexpected error reading %s: %s",
-                    reg_address_manual,
-                    exc,
-                )
-                self.close()
-                return None
-
-        if not result or getattr(result, "isError", lambda: True)():
-            _LOGGER.warning(
-                "ECL Modbus: Modbus error or no response for address %s: %s",
-                reg_address_manual,
-                result,
-            )
-            return None
-
-        regs = getattr(result, "registers", None)
-        if not regs:
-            _LOGGER.warning(
-                "ECL Modbus: empty register response for address %s: %s",
-                reg_address_manual,
-                result,
-            )
-            return None
-
-        return list(regs)
-
-    def read_float(self, reg_address_manual: int) -> float | None:
-        """Read a 32-bit float from two holding registers."""
-        regs = self._read_registers(reg_address_manual, count=2)
-        if regs is None:
-            return None
-        try:
-            return self._regs_to_float_be(regs)
-        except Exception as exc:  # noqa: BLE001
-            _LOGGER.error(
-                "ECL Modbus: failed to convert regs %s at addr %s to float: %s",
-                regs,
-                reg_address_manual,
-                exc,
-            )
-            return None
-
-    def read_int16(self, reg_address_manual: int, signed: bool = True) -> int | None:
-        """Read a single 16-bit register as int."""
-        regs = self._read_registers(reg_address_manual, count=1)
-        if regs is None:
-            return None
-        raw = regs[0]
-        if signed and raw > 0x7FFF:
-            raw -= 0x10000
-        return raw
-
-    def read_string(self, reg_address_manual: int, reg_count: int) -> str | None:
-        """Read an ASCII string stored across multiple registers."""
-        regs = self._read_registers(reg_address_manual, count=reg_count)
-        if regs is None:
-            return None
-        try:
-            raw_bytes = bytearray()
-            for reg in regs:
-                raw_bytes.extend(reg.to_bytes(2, byteorder="big"))
-            text = raw_bytes.decode("ascii", errors="ignore").strip("\x00").strip()
-            return text or None
-        except Exception as exc:  # noqa: BLE001
-            _LOGGER.error(
-                "ECL Modbus: failed to decode string at addr %s (regs=%s): %s",
-                reg_address_manual,
-                regs,
-                exc,
-            )
-            return None
-
-    @staticmethod
-    def _regs_to_float_be(registers: list[int]) -> float:
-        """Convert two registers (big endian) to a Python float."""
-        if len(registers) < 2:
-            raise ValueError("Not enough registers for float")
-        raw = (registers[0] << 16) | registers[1]
-        return struct.unpack(">f", raw.to_bytes(4, byteorder="big"))[0]
-
-
-# -----------------------------------------------------------------------------
-# Coordinator (one global poll loop for all enabled registers)
-# -----------------------------------------------------------------------------
-
-class EclModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
-    """Poll all enabled registers at a single global interval."""
-
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        hub: EclModbusHub,
-        registers: list[RegisterDef],
-        scan_interval_sec: int,
-    ) -> None:
-        super().__init__(
-            hass,
-            _LOGGER,
-            name="ECL Modbus Coordinator",
-            update_interval=timedelta(seconds=scan_interval_sec),
-        )
-        self._hub = hub
-        self._registers = registers
-
-    async def _async_update_data(self) -> dict[str, Any]:
-        """Fetch all enabled register values."""
-        def _read_all() -> dict[str, Any]:
-            data: dict[str, Any] = {}
-            for reg in self._registers:
-                if reg.reg_type == RegisterType.FLOAT:
-                    data[reg.key] = self._hub.read_float(reg.address)
-                elif reg.reg_type == RegisterType.INT16:
-                    data[reg.key] = self._hub.read_int16(reg.address, signed=reg.signed)
-                elif reg.reg_type == RegisterType.STRING16:
-                    # String16 is typically 16 chars -> 8 registers
-                    data[reg.key] = self._hub.read_string(reg.address, reg_count=8)
-                elif reg.reg_type == RegisterType.STRING32:
-                    # String32 is typically 32 chars -> 16 registers
-                    data[reg.key] = self._hub.read_string(reg.address, reg_count=16)
-                else:
-                    data[reg.key] = None
-            return data
-
-        try:
-            return await self.hass.async_add_executor_job(_read_all)
-        except Exception as exc:  # noqa: BLE001
-            raise UpdateFailed(f"ECL Modbus update failed: {exc}") from exc
-
-
-# -----------------------------------------------------------------------------
-# Entities
-# -----------------------------------------------------------------------------
-
-class EclModbusRegisterSensor(CoordinatorEntity[EclModbusCoordinator], SensorEntity):
-    """Generic sensor that exposes one read-only register from the coordinator."""
-
-    def __init__(
-        self,
-        coordinator: EclModbusCoordinator,
-        entry_title: str,
-        reg: RegisterDef,
-    ) -> None:
+    def __init__(self, coordinator, entry_title: str, reg: RegisterDef) -> None:
         super().__init__(coordinator)
         self._reg = reg
-
-        # Entity identity
         self._attr_name = f"{entry_title} {reg.name}"
         self._attr_unique_id = f"{DOMAIN}_{reg.key}"
-
-        # Presentation
         self._attr_native_unit_of_measurement = reg.unit
         self._attr_device_class = reg.device_class
         self._attr_state_class = reg.state_class
         self._attr_icon = reg.icon
-
-        # Useful debugging metadata
         self._attr_extra_state_attributes = {
             "ecl_modbus_register": reg.address,
             "ecl_modbus_type": reg.reg_type.value,
-            "ecl_modbus_writable": reg.writable,
+            "ecl_modbus_writable": getattr(reg, "writable", False),
         }
 
     @property
     def device_info(self) -> dict:
-        """Group all entities under a single ECL device."""
         return {
             "identifiers": {(DOMAIN, "ecl_modbus")},
             "name": "ECL Modbus",
@@ -299,89 +44,26 @@ class EclModbusRegisterSensor(CoordinatorEntity[EclModbusCoordinator], SensorEnt
 
     @property
     def native_value(self) -> Any:
-        """Return the latest value from the coordinator."""
+        if not self.coordinator.data:
+            return None
+
         raw = self.coordinator.data.get(self._reg.key)
         if raw is None:
             return None
 
-        # Strings etc.
         if self._reg.reg_type in (RegisterType.STRING16, RegisterType.STRING32):
             return raw
 
-        # Numeric output
-        if self._reg.reg_type == RegisterType.INT16:
-            # Prefer int output if no scaling is needed
-            if self._reg.scale == 1.0 and isinstance(raw, int):
-                return raw
-            try:
-                value = float(raw) * float(self._reg.scale)
-            except (TypeError, ValueError):
-                return None
-        else:
-            # FLOAT
-            try:
-                value = float(raw) * float(self._reg.scale)
-            except (TypeError, ValueError):
-                return None
+        try:
+            value = float(raw) * float(self._reg.scale)
+        except (TypeError, ValueError):
+            return None
 
-        # Small niceties for common types
         if self._reg.device_class == "temperature":
             return round(value, 1)
         if self._reg.unit == "%":
             return round(value, 1)
-
         return value
-
-
-# -----------------------------------------------------------------------------
-# Platform setup
-# -----------------------------------------------------------------------------
-
-def _clamp_scan_interval(value: Any) -> int:
-    """Clamp scan interval to a safe range for RS485 polling."""
-    try:
-        sec = int(value)
-    except (TypeError, ValueError):
-        sec = DEFAULT_SCAN_INTERVAL
-    if sec < 5:
-        return 5
-    if sec > 3600:
-        return 3600
-    return sec
-
-
-def _default_enabled(reg: RegisterDef) -> bool:
-    """Return whether a register should be enabled by default."""
-    if reg.key in ("s3_temperature", "s4_temperature"):
-        return True
-    return False
-
-
-def _entry_store(hass: HomeAssistant, entry: ConfigEntry) -> dict[str, Any]:
-    """Ensure a dict store for this entry in hass.data."""
-    domain_data = hass.data.setdefault(DOMAIN, {})
-    store = domain_data.get(entry.entry_id)
-    if not isinstance(store, dict):
-        store = {}
-        domain_data[entry.entry_id] = store
-    return store
-
-
-def get_hub_for_entry(hass: HomeAssistant, entry: ConfigEntry) -> EclModbusHub:
-    """Get (or create) the EclModbusHub for this config entry."""
-    store = _entry_store(hass, entry)
-    hub = store.get("hub")
-
-    if isinstance(hub, EclModbusHub):
-        return hub
-
-    port = entry.data[CONF_PORT]
-    baudrate = entry.data.get(CONF_BAUDRATE, DEFAULT_BAUDRATE)
-    slave_id = entry.data.get(CONF_SLAVE_ID, DEFAULT_SLAVE_ID)
-
-    hub = EclModbusHub(port=port, baudrate=baudrate, slave_id=slave_id)
-    store["hub"] = hub
-    return hub
 
 
 async def async_setup_entry(
@@ -389,45 +71,13 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up sensors based on a config entry (UI configuration)."""
-    entry_title = entry.data.get(CONF_NAME, DEFAULT_NAME)
-    hub = get_hub_for_entry(hass, entry)
+    store = hass.data[DOMAIN][entry.entry_id]
+    coordinator = store["coordinator"]
+    entry_title: str = store["entry_title"]
+    regs: list[RegisterDef] = store["registers"]
 
-    # Global polling interval (one coordinator for everything)
-    scan_interval_sec = _clamp_scan_interval(entry.options.get(CONF_SCAN_INTERVAL))
-
-    # Build enabled register list from options (includes RW so coordinator can serve number.py later)
-    enabled_regs: list[RegisterDef] = []
-    for reg in ALL_REGISTERS:
-        enabled = bool(entry.options.get(option_key(reg.key), _default_enabled(reg)))
-        if enabled:
-            enabled_regs.append(reg)
-
-    coordinator = EclModbusCoordinator(
-        hass=hass,
-        hub=hub,
-        registers=enabled_regs,
-        scan_interval_sec=scan_interval_sec,
+    ro_regs = [r for r in regs if not getattr(r, "writable", False)]
+    async_add_entities(
+        [EclModbusRegisterSensor(coordinator, entry_title, r) for r in ro_regs],
+        update_before_add=False,
     )
-
-    # Save coordinator for other platforms (number/select) to reuse
-    store = _entry_store(hass, entry)
-    store["coordinator"] = coordinator
-    store["registers"] = enabled_regs
-
-    # First refresh before adding entities (better UX)
-    await coordinator.async_config_entry_first_refresh()
-
-    # Create ONLY read-only sensors here (RW registers will be handled elsewhere)
-    ro_regs = [r for r in enabled_regs if not getattr(r, "writable", False)]
-    entities: list[SensorEntity] = [
-        EclModbusRegisterSensor(coordinator, entry_title, reg) for reg in ro_regs
-    ]
-
-    async_add_entities(entities, update_before_add=False)
-
-    async def _async_close_hub(event: Any) -> None:
-        """Close the Modbus client when Home Assistant stops."""
-        hub.close()
-
-    hass.bus.async_listen_once("homeassistant_stop", _async_close_hub)

--- a/custom_components/ecl_modbus/sensor.py
+++ b/custom_components/ecl_modbus/sensor.py
@@ -1,6 +1,15 @@
 from __future__ import annotations
 
-"""Sensor platform for the ECL Modbus integration."""
+"""Sensor platform for the ECL Modbus integration.
+
+This module is intentionally built around a single register definition list
+(`registers.py`). That makes it easy to add new registers without copy/paste
+of entity classes and setup logic.
+
+The integration uses a DataUpdateCoordinator to poll all enabled registers at
+one global interval. This avoids serial port locking issues and improves RS485
+stability compared to per-entity polling.
+"""
 
 import logging
 import struct
@@ -12,60 +21,34 @@ from pymodbus.client import ModbusSerialClient
 from pymodbus.exceptions import ModbusIOException
 
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.const import (
-    CONF_NAME,
-    CONF_PORT,
-    UnitOfTemperature,
-    PERCENTAGE,
-)
-from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_NAME, CONF_PORT
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+    UpdateFailed,
+)
 
 from .const import (
     DOMAIN,
-    DEFAULT_NAME,
     DEFAULT_BAUDRATE,
+    DEFAULT_NAME,
+    DEFAULT_SCAN_INTERVAL,
     DEFAULT_SLAVE_ID,
     CONF_BAUDRATE,
+    CONF_SCAN_INTERVAL,
     CONF_SLAVE_ID,
-    CONF_ENABLE_S1,
-    CONF_ENABLE_S2,
-    CONF_ENABLE_S3,
-    CONF_ENABLE_S4,
-    CONF_ENABLE_S5,
-    CONF_ENABLE_S6,
-    CONF_ENABLE_IP_ADDRESS,
-    CONF_ENABLE_MAC_ADDRESS,
-    CONF_ENABLE_VALVE_POSITION,
-    CONF_ENABLE_HEAT_FLOW_REF,
-    CONF_ENABLE_HEAT_RETURN_REF,
 )
+from .registers import ALL_REGISTERS, RegisterDef, RegisterType, option_key
 
 _LOGGER = logging.getLogger(__name__)
 
-# Home Assistant will poll all entities in this platform using this interval
-SCAN_INTERVAL = timedelta(seconds=30)
 
-# Temperature sensor registers (manual addresses from the ECL documentation)
-REG_S1_MANUAL = 4000
-REG_S2_MANUAL = 4010
-REG_S3_MANUAL = 4020
-REG_S4_MANUAL = 4030
-REG_S5_MANUAL = 4040
-REG_S6_MANUAL = 4050
-
-# Ethernet IP and MAC address registers (String16 / String32)
-REG_ETH_IP_MANUAL = 2100   # String16
-REG_ETH_MAC_MANUAL = 2110  # String32
-
-# Valve position register (float, %)
-REG_VALVE_POSITION_MANUAL = 21700
-
-# Heat reference registers
-REG_HEAT_FLOW_REF = 21200     # Float C (0–150°C)
-REG_HEAT_RETURN_REF = 21210  # Float C (5 – 150°C)
-
+# -----------------------------------------------------------------------------
+# Modbus hub (serial client + low level readers)
+# -----------------------------------------------------------------------------
 
 class EclModbusHub:
     """Handle Modbus communication with the ECL controller."""
@@ -116,20 +99,16 @@ class EclModbusHub:
                 pass
         self._client = None
 
-    # ---------- LOW LEVEL READERS ----------
+    def _read_registers(self, reg_address_manual: int, count: int) -> list[int] | None:
+        """Read raw holding registers.
 
-    def _read_registers(
-        self,
-        reg_address_manual: int,
-        count: int,
-    ):
-        """Internal helper: read raw holding registers."""
+        ECL documentation uses 1-based manual addresses.
+        pymodbus expects 0-based PDU addresses.
+        """
         with self._lock:
             try:
                 self._ensure_client()
-                # Manual address is 1-based, Modbus PDU uses 0-based
                 pdu_address = reg_address_manual - 1
-
                 result = self._client.read_holding_registers(
                     address=pdu_address,
                     count=count,
@@ -161,8 +140,8 @@ class EclModbusHub:
             )
             return None
 
-        registers = getattr(result, "registers", None)
-        if not registers:
+        regs = getattr(result, "registers", None)
+        if not regs:
             _LOGGER.warning(
                 "ECL Modbus: empty register response for address %s: %s",
                 reg_address_manual,
@@ -170,46 +149,50 @@ class EclModbusHub:
             )
             return None
 
-        return registers
+        return list(regs)
 
     def read_float(self, reg_address_manual: int) -> float | None:
-        """Read a 32-bit float from two holding registers (4000+/6000+ area)."""
-        registers = self._read_registers(reg_address_manual, count=2)
-        if registers is None:
+        """Read a 32-bit float from two holding registers."""
+        regs = self._read_registers(reg_address_manual, count=2)
+        if regs is None:
             return None
-
         try:
-            return self._regs_to_float_be(registers)
+            return self._regs_to_float_be(regs)
         except Exception as exc:  # noqa: BLE001
             _LOGGER.error(
-                "ECL Modbus: failed to convert registers %s at addr %s to float: %s",
-                registers,
+                "ECL Modbus: failed to convert regs %s at addr %s to float: %s",
+                regs,
                 reg_address_manual,
                 exc,
             )
             return None
 
-    def read_string(self, reg_address_manual: int, reg_count: int) -> str | None:
-        """Read a string stored as ASCII across multiple registers."""
-        registers = self._read_registers(reg_address_manual, count=reg_count)
-        if registers is None:
+    def read_int16(self, reg_address_manual: int, signed: bool = True) -> int | None:
+        """Read a single 16-bit register as int."""
+        regs = self._read_registers(reg_address_manual, count=1)
+        if regs is None:
             return None
+        raw = regs[0]
+        if signed and raw > 0x7FFF:
+            raw -= 0x10000
+        return raw
 
+    def read_string(self, reg_address_manual: int, reg_count: int) -> str | None:
+        """Read an ASCII string stored across multiple registers."""
+        regs = self._read_registers(reg_address_manual, count=reg_count)
+        if regs is None:
+            return None
         try:
-            # Each register is 2 bytes (big endian)
             raw_bytes = bytearray()
-            for reg in registers:
+            for reg in regs:
                 raw_bytes.extend(reg.to_bytes(2, byteorder="big"))
-
             text = raw_bytes.decode("ascii", errors="ignore").strip("\x00").strip()
-            if not text:
-                return None
-            return text
+            return text or None
         except Exception as exc:  # noqa: BLE001
             _LOGGER.error(
-                "ECL Modbus: failed to decode string from addr %s (regs=%s): %s",
+                "ECL Modbus: failed to decode string at addr %s (regs=%s): %s",
                 reg_address_manual,
-                registers,
+                regs,
                 exc,
             )
             return None
@@ -219,20 +202,93 @@ class EclModbusHub:
         """Convert two registers (big endian) to a Python float."""
         if len(registers) < 2:
             raise ValueError("Not enough registers for float")
-        # High word first (big endian)
         raw = (registers[0] << 16) | registers[1]
         return struct.unpack(">f", raw.to_bytes(4, byteorder="big"))[0]
 
 
-# ---------- SENSOR ENTITIES ----------
+# -----------------------------------------------------------------------------
+# Coordinator (one global poll loop for all enabled registers)
+# -----------------------------------------------------------------------------
+
+class EclModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """Poll all enabled registers at a single global interval."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        hub: EclModbusHub,
+        registers: list[RegisterDef],
+        scan_interval_sec: int,
+    ) -> None:
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="ECL Modbus Coordinator",
+            update_interval=timedelta(seconds=scan_interval_sec),
+        )
+        self._hub = hub
+        self._registers = registers
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Fetch all enabled register values."""
+        def _read_all() -> dict[str, Any]:
+            data: dict[str, Any] = {}
+            for reg in self._registers:
+                if reg.reg_type == RegisterType.FLOAT:
+                    data[reg.key] = self._hub.read_float(reg.address)
+                elif reg.reg_type == RegisterType.INT16:
+                    data[reg.key] = self._hub.read_int16(reg.address, signed=reg.signed)
+                elif reg.reg_type == RegisterType.STRING16:
+                    # String16 is typically 16 chars -> 8 registers
+                    data[reg.key] = self._hub.read_string(reg.address, reg_count=8)
+                elif reg.reg_type == RegisterType.STRING32:
+                    # String32 is typically 32 chars -> 16 registers
+                    data[reg.key] = self._hub.read_string(reg.address, reg_count=16)
+                else:
+                    data[reg.key] = None
+            return data
+
+        try:
+            return await self.hass.async_add_executor_job(_read_all)
+        except Exception as exc:  # noqa: BLE001
+            raise UpdateFailed(f"ECL Modbus update failed: {exc}") from exc
 
 
-class EclModbusBaseEntity(SensorEntity):
-    """Base class to share device_info between all ECL entities."""
+# -----------------------------------------------------------------------------
+# Entities
+# -----------------------------------------------------------------------------
+
+class EclModbusRegisterSensor(CoordinatorEntity[EclModbusCoordinator], SensorEntity):
+    """Generic sensor that exposes one register from the coordinator."""
+
+    def __init__(
+        self,
+        coordinator: EclModbusCoordinator,
+        entry_title: str,
+        reg: RegisterDef,
+    ) -> None:
+        super().__init__(coordinator)
+        self._reg = reg
+
+        # Entity identity
+        self._attr_name = f"{entry_title} {reg.name}"
+        self._attr_unique_id = f"{DOMAIN}_{reg.key}"
+
+        # Presentation
+        self._attr_native_unit_of_measurement = reg.unit
+        self._attr_device_class = reg.device_class
+        self._attr_state_class = reg.state_class
+        self._attr_icon = reg.icon
+
+        # Useful debugging metadata
+        self._attr_extra_state_attributes = {
+            "ecl_modbus_register": reg.address,
+            "ecl_modbus_type": reg.reg_type.value,
+        }
 
     @property
     def device_info(self) -> dict:
-        """Return device info so all sensors are grouped under one ECL device."""
+        """Group all entities under a single ECL device."""
         return {
             "identifiers": {(DOMAIN, "ecl_modbus")},
             "name": "ECL Modbus",
@@ -240,171 +296,60 @@ class EclModbusBaseEntity(SensorEntity):
             "model": "ECL 120/220",
         }
 
+    @property
+    def native_value(self) -> Any:
+        """Return the latest value from the coordinator."""
+        raw = self.coordinator.data.get(self._reg.key)
+        if raw is None:
+            return None
 
-class EclModbusTemperatureSensor(EclModbusBaseEntity):
-    """Temperature sensor (S1–S6) read from the ECL controller."""
+        # Apply scaling for numeric types (if configured)
+        if self._reg.reg_type in (RegisterType.FLOAT, RegisterType.INT16):
+            try:
+                value = float(raw) * float(self._reg.scale)
+            except (TypeError, ValueError):
+                return None
 
-    _attr_state_class = "measurement"
-    _attr_device_class = "temperature"
-    _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+            # Common nicety: round temperatures and percentages a bit
+            if self._reg.device_class == "temperature":
+                return round(value, 1)
+            if self._reg.unit == "%":
+                return round(value, 1)
 
-    def __init__(
-        self,
-        hub: EclModbusHub,
-        name: str,
-        reg_address_manual: int,
-        unique_suffix: str,
-    ) -> None:
-        self._hub = hub
-        self._reg_address_manual = reg_address_manual
-        self._attr_name = name
-        self._attr_unique_id = f"ecl_modbus_{unique_suffix}"
-        self._attr_extra_state_attributes = {
-            "ecl_modbus_register": reg_address_manual
-        }
+            # Default numeric output
+            # If integer scaling isn't used, keep int-ish values readable
+            return value
 
-    async def async_update(self) -> None:
-        """Fetch a new temperature value from the ECL via Modbus."""
-        _LOGGER.debug(
-            "ECL Modbus: async_update started for %s (addr %s)",
-            self.name,
-            self._reg_address_manual,
-        )
-
-        value = await self.hass.async_add_executor_job(
-            self._hub.read_float,
-            self._reg_address_manual,
-        )
-
-        if value is None:
-            _LOGGER.debug(
-                "ECL Modbus: no new value for %s (addr %s) – keeping previous state",
-                self.name,
-                self._reg_address_manual,
-            )
-            return
-
-        rounded = round(value, 1)
-        _LOGGER.debug(
-            "ECL Modbus: updating %s (addr %s) to %.1f °C",
-            self.name,
-            self._reg_address_manual,
-            rounded,
-        )
-        self._attr_native_value = rounded
+        # Strings, etc.
+        return raw
 
 
-class EclModbusStringSensor(EclModbusBaseEntity):
-    """String-based sensor (e.g. IP address, MAC address) from ECL."""
+# -----------------------------------------------------------------------------
+# Platform setup
+# -----------------------------------------------------------------------------
 
-    _attr_state_class = None  # no numeric state
-
-    def __init__(
-        self,
-        hub: EclModbusHub,
-        name: str,
-        reg_address_manual: int,
-        reg_count: int,
-        unique_suffix: str,
-    ) -> None:
-        self._hub = hub
-        self._reg_address_manual = reg_address_manual
-        self._reg_count = reg_count
-        self._attr_name = name
-        self._attr_unique_id = f"ecl_modbus_{unique_suffix}"
-        self._attr_extra_state_attributes = {
-            "ecl_modbus_register": reg_address_manual,
-            "ecl_modbus_reg_count": reg_count,
-        }
-
-    async def async_update(self) -> None:
-        """Fetch the latest string value from ECL via Modbus."""
-        _LOGGER.debug(
-            "ECL Modbus: async_update (string) started for %s (addr %s, count %s)",
-            self.name,
-            self._reg_address_manual,
-            self._reg_count,
-        )
-
-        value = await self.hass.async_add_executor_job(
-            self._hub.read_string,
-            self._reg_address_manual,
-            self._reg_count,
-        )
-
-        if value is None:
-            _LOGGER.debug(
-                "ECL Modbus: no new string value for %s (addr %s) – keeping previous",
-                self.name,
-                self._reg_address_manual,
-            )
-            return
-
-        _LOGGER.debug(
-            "ECL Modbus: updating %s (addr %s) to '%s'",
-            self.name,
-            self._reg_address_manual,
-            value,
-        )
-        self._attr_native_value = value
+def _clamp_scan_interval(value: Any) -> int:
+    """Clamp scan interval to a safe range for RS485 polling."""
+    try:
+        sec = int(value)
+    except (TypeError, ValueError):
+        sec = DEFAULT_SCAN_INTERVAL
+    if sec < 5:
+        return 5
+    if sec > 3600:
+        return 3600
+    return sec
 
 
-class EclModbusValvePositionSensor(EclModbusBaseEntity):
-    """Valve position sensor (float, percentage) from ECL."""
-
-    _attr_state_class = "measurement"
-    _attr_native_unit_of_measurement = PERCENTAGE
-
-    def __init__(
-        self,
-        hub: EclModbusHub,
-        name: str,
-        reg_address_manual: int,
-        unique_suffix: str,
-    ) -> None:
-        self._hub = hub
-        self._reg_address_manual = reg_address_manual
-        self._attr_name = name
-        self._attr_unique_id = f"ecl_modbus_{unique_suffix}"
-        self._attr_extra_state_attributes = {
-            "ecl_modbus_register": reg_address_manual
-        }
-
-    async def async_update(self) -> None:
-        """Fetch a new valve position value from ECL via Modbus."""
-        _LOGGER.debug(
-            "ECL Modbus: async_update (valve position) started for %s (addr %s)",
-            self.name,
-            self._reg_address_manual,
-        )
-
-        value = await self.hass.async_add_executor_job(
-            self._hub.read_float,
-            self._reg_address_manual,
-        )
-
-        if value is None:
-            _LOGGER.debug(
-                "ECL Modbus: no new valve position for %s (addr %s) – keeping previous",
-                self.name,
-                self._reg_address_manual,
-            )
-            return
-
-        rounded = round(value, 1)
-        _LOGGER.debug(
-            "ECL Modbus: updating valve position %s (addr %s) to %.1f %%",
-            self.name,
-            self._reg_address_manual,
-            rounded,
-        )
-        self._attr_native_value = rounded
+def _default_enabled(reg: RegisterDef) -> bool:
+    """Return whether a register should be enabled by default."""
+    # Keep defaults conservative. Most users typically want S3/S4 first.
+    if reg.key in ("s3_temperature", "s4_temperature"):
+        return True
+    return False
 
 
-# ---------- PLATFORM SETUP ----------
-
-
-def get_hub_for_entry(hass: HomeAssistant, entry: ConfigEntry) -> "EclModbusHub":
+def get_hub_for_entry(hass: HomeAssistant, entry: ConfigEntry) -> EclModbusHub:
     """Get (or create) the EclModbusHub for this config entry."""
     data = hass.data.setdefault(DOMAIN, {})
     hub: EclModbusHub | None = data.get(entry.entry_id)
@@ -426,115 +371,34 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up sensors based on a config entry (UI configuration)."""
-    name = entry.data.get(CONF_NAME, DEFAULT_NAME)
+    entry_title = entry.data.get(CONF_NAME, DEFAULT_NAME)
     hub = get_hub_for_entry(hass, entry)
 
-    options = entry.options
+    # Global polling interval (one coordinator for everything)
+    scan_interval_sec = _clamp_scan_interval(entry.options.get(CONF_SCAN_INTERVAL))
 
-    def opt(key: str, default: bool) -> bool:
-        """Helper to read boolean options with a default."""
-        return bool(options.get(key, default))
+    # Build enabled register list from options
+    enabled_regs: list[RegisterDef] = []
+    for reg in ALL_REGISTERS:
+        enabled = bool(entry.options.get(option_key(reg.key), _default_enabled(reg)))
+        if enabled:
+            enabled_regs.append(reg)
 
-    entities: list[SensorEntity] = []
+    coordinator = EclModbusCoordinator(
+        hass=hass,
+        hub=hub,
+        registers=enabled_regs,
+        scan_interval_sec=scan_interval_sec,
+    )
 
-    # ---------- Temperature sensors S1–S6 ----------
+    # Do a first refresh before adding entities (better UX)
+    await coordinator.async_config_entry_first_refresh()
 
-    if opt(CONF_ENABLE_S1, False):
-        entities.append(
-            EclModbusTemperatureSensor(
-                hub, f"{name} S1 temperature", REG_S1_MANUAL, "s1_temp"
-            )
-        )
-    if opt(CONF_ENABLE_S2, False):
-        entities.append(
-            EclModbusTemperatureSensor(
-                hub, f"{name} S2 temperature", REG_S2_MANUAL, "s2_temp"
-            )
-        )
-    if opt(CONF_ENABLE_S3, True):
-        entities.append(
-            EclModbusTemperatureSensor(
-                hub, f"{name} S3 temperature", REG_S3_MANUAL, "s3_temp"
-            )
-        )
-    if opt(CONF_ENABLE_S4, True):
-        entities.append(
-            EclModbusTemperatureSensor(
-                hub, f"{name} S4 temperature", REG_S4_MANUAL, "s4_temp"
-            )
-        )
-    if opt(CONF_ENABLE_S5, False):
-        entities.append(
-            EclModbusTemperatureSensor(
-                hub, f"{name} S5 temperature", REG_S5_MANUAL, "s5_temp"
-            )
-        )
-    if opt(CONF_ENABLE_S6, False):
-        entities.append(
-            EclModbusTemperatureSensor(
-                hub, f"{name} S6 temperature", REG_S6_MANUAL, "s6_temp"
-            )
-        )
+    entities: list[SensorEntity] = [
+        EclModbusRegisterSensor(coordinator, entry_title, reg) for reg in enabled_regs
+    ]
 
-    # ---------- Extra sensors: IP, MAC, valve position ----------
-
-    if opt(CONF_ENABLE_IP_ADDRESS, False):
-        # String16 → 16 characters → 8 registers (2 bytes per register)
-        entities.append(
-            EclModbusStringSensor(
-                hub=hub,
-                name=f"{name} Ethernet IP address",
-                reg_address_manual=REG_ETH_IP_MANUAL,
-                reg_count=8,
-                unique_suffix="eth_ip",
-            )
-        )
-
-    if opt(CONF_ENABLE_MAC_ADDRESS, False):
-        # String32 → 32 characters → 16 registers
-        entities.append(
-            EclModbusStringSensor(
-                hub=hub,
-                name=f"{name} Ethernet MAC address",
-                reg_address_manual=REG_ETH_MAC_MANUAL,
-                reg_count=16,
-                unique_suffix="eth_mac",
-            )
-        )
-
-    if opt(CONF_ENABLE_VALVE_POSITION, False):
-        entities.append(
-            EclModbusValvePositionSensor(
-                hub=hub,
-                name=f"{name} valve position",
-                reg_address_manual=REG_VALVE_POSITION_MANUAL,
-                unique_suffix="valve_position",
-            )
-        )
-
-    # Heat Flow Reference (float °C 0–150)
-    if opt(CONF_ENABLE_HEAT_FLOW_REF, False):
-        entities.append(
-            EclModbusTemperatureSensor(
-                hub,
-                f"{name} heat flow reference",
-                REG_HEAT_FLOW_REF,
-                "heat_flow_ref",
-            )
-        )
-
-    # Heat Return Compensated Reference (float °C 5–150)
-    if opt(CONF_ENABLE_HEAT_RETURN_REF, False):
-        entities.append(
-            EclModbusTemperatureSensor(
-                hub,
-                f"{name} heat return reference",
-                REG_HEAT_RETURN_REF,
-                "heat_return_ref",
-            )
-        )
-
-    async_add_entities(entities, update_before_add=True)
+    async_add_entities(entities, update_before_add=False)
 
     async def _async_close_hub(event: Any) -> None:
         """Close the Modbus client when Home Assistant stops."""


### PR DESCRIPTION
This pull request introduces version 2.0.0 of the ECL Modbus integration.

Key changes:
- Fully register-driven architecture
- Central register definitions (registers.py)
- Read-only registers exposed as sensors
- Read/write registers exposed as Number and Select entities
- Improved Modbus stability using a shared DataUpdateCoordinator
- Tested on Danfoss ECL 120 (expected to work on ECL 220)

This refactor makes it significantly easier to add new registers going forward.