### PR TITLE
Add additional ECL control and tuning registers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,22 +10,18 @@ It is tested on **ECL 120**, but **ECL 220 uses the same register map**, so it *
 ## 🔧 Features
 Current supported features:
 
-| **Addr** | **RW** | **Name**                               | **Type** | **Unit** | **Min** | **Max** | **Description**                                                                   |
-|----------|--------|----------------------------------------|----------|----------|---------|---------|-----------------------------------------------------------------------------------|
-| 4000     |    R   | **Value of Temperature Sensor S1**     | Float    | °C       | -64     | 192     | Current value of temperature sensor S1                                            |
-| 4010     |    R   | **Value of Temperature Sensor S2**     | Float    | °C       | -64     | 192     | Current value of temperature sensor S2                                            |
-| 4020     |    R   | **Value of Temperature Sensor S3**     | Float    | °C       | -64     | 192     | Current value of temperature sensor S3                                            |
-| 4030     |    R   | **Value of Temperature Sensor S4**     | Float    | °C       | -64     | 192     | Current value of temperature sensor S4                                            |
-| 4040     |    R   | **Value of Temperature Sensor S5**     | Float    | °C       | -64     | 192     | Current value of temperature sensor S5                                            |
-| 4050     |    R   | **Value of Temperature Sensor S6**     | Float    | °C       | -64     | 192     | Current value of temperature sensor S6                                            |
-| 2100     |    R   | **Ethernet IP Address**                | String16 |          |         |         | Ethernet IP Address                                                               |
-| 2110     |    R   | **Ethernet MAC Address**               | String32 |          |         |         | Ethernet MAC Address                                                              |
-| 21000    |   RW   | **Operation Mode**                     | UInt16   |          | 0       | 10      | Current operation mode: 0 = Automatic 1 = Comfort 2 = Saving 3 = Frost protection |
-| 21001    |    R   | **Operation Status**                   | UInt16   |          | 0       | 10      | Current operation status: 0 = Comfort 1 = Saving 2 = Frost Protection             |
-| 21200    |    R   | **Heat Flow Temperature Reference**    | Float    | °C       | 0       | 150     | Calculated heat flow reference                                                    |
-| 21206    |    R   | **Heat Weather Compensated Reference** | Float    | °C       | -150    | 150     | Calculated value from the weather compensator                                     |
-| 21210    |   RW   | **Heat Return Temperature Reference**  | Float    | °C       | 5       | 150     | Reference for Return Limiter                                                      |
-| 21700    |    R   | **Heat Valve Position**                | Float    | %        | 0       | 1       | Scale 100 – Estimated position of motor                                           |
+The list of supported registers is continuously expanding.
+
+The authoritative source for supported registers is:
+- `custom_components/ecl_modbus/registers.py`
+
+Each register definition includes:
+- Modbus address
+- Read / Write support
+- Data type
+- Unit
+- Scaling
+- Min / Max / Step (where applicable)                                   |
 
 ### Fully configurable
 - Enable/disable each sensor individually  
@@ -158,3 +154,27 @@ The document is shared with permission from Danfoss.
 
 ## 📄 License
 MIT License
+
+## ⚠️ Disclaimer
+
+This integration is provided **as-is**, without any guarantees or warranties of any kind.
+
+- The author is **not affiliated with Danfoss**.
+- The author is **not a professional developer**.
+- This integration may contain bugs, incorrect register mappings, or incomplete implementations.
+- Writing values to the controller **may affect system behavior** and could potentially cause malfunction or damage if used incorrectly.
+
+**You are fully responsible for:**
+- Verifying register addresses and values
+- Testing changes in a safe environment
+- Ensuring that critical heating functions remain safe and operational
+
+The author takes **no responsibility or liability** for:
+- Damaged equipment
+- Incorrect heating behavior
+- Increased energy consumption
+- Loss of comfort or system downtime
+
+If you are unsure about a parameter or register — **do not write to it**.
+
+Use this integration **at your own risk**.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Each register definition includes:
 - Data type
 - Unit
 - Scaling
-- Min / Max / Step (where applicable)                                   |
+- Min / Max / Step (where applicable)
 
 ### Fully configurable
 - Enable/disable each sensor individually  
@@ -138,6 +138,20 @@ This project is community-driven — PRs, testing, and feedback are highly appre
 
 GitHub:  
 👉 https://github.com/nichlasrohde/ha-ecl-modbus
+
+---
+
+## ☕ Support the project
+
+This project is developed and maintained in my spare time as a hobby.
+
+If you find it useful and would like to support continued development,  
+you’re very welcome to do so — completely optional.
+
+🇩🇰 **MobilePay (Denmark):** `9316PV`
+[Support via MobilePay](https://qr.mobilepay.dk/box/82f3141c-2907-485e-b47f-518f9d789297/pay-in)
+
+Thank you for the support ❤️
 
 ---
 

--- a/custom_components/ecl_modbus/config_flow.py
+++ b/custom_components/ecl_modbus/config_flow.py
@@ -152,8 +152,17 @@ class EclModbusOptionsFlow(config_entries.OptionsFlow):
         # platforms decide how to expose them: sensors vs numbers/selects)
         for reg in ALL_REGISTERS:
             k = option_key(reg.key)
-            default_value = bool(options.get(k, reg.key in default_enabled_keys))
-            schema_dict[vol.Optional(k, default=default_value)] = bool
+            default_value = opt_bool(k, reg.key in default_enabled_keys)
+
+            label = f"{reg.name} ({reg.address})"
+
+            schema_dict[
+                vol.Optional(
+                    k,
+                    default=default_value,
+                    description={"name": label},
+                )
+            ] = bool
 
         # Global polling interval (seconds)
         schema_dict[

--- a/custom_components/ecl_modbus/config_flow.py
+++ b/custom_components/ecl_modbus/config_flow.py
@@ -139,9 +139,13 @@ class EclModbusOptionsFlow(config_entries.OptionsFlow):
         options = dict(self._entry.options)
 
         if user_input is not None:
-            # IMPORTANT: merge with existing options to avoid losing keys
+            # Merge with existing options to avoid losing keys
             new_options = {**options, **user_input}
             return self.async_create_entry(title="", data=new_options)
+
+        def opt_bool(key: str, default: bool) -> bool:
+            """Read a boolean option with a default."""
+            return bool(options.get(key, default))
 
         # Default enable behaviour (conservative)
         default_enabled_keys = {"s3_temperature", "s4_temperature"}

--- a/custom_components/ecl_modbus/config_flow.py
+++ b/custom_components/ecl_modbus/config_flow.py
@@ -139,34 +139,23 @@ class EclModbusOptionsFlow(config_entries.OptionsFlow):
         options = dict(self._entry.options)
 
         if user_input is not None:
-            # Merge with existing options to avoid losing keys
+            # Merge with existing options so we don't lose old keys
             new_options = {**options, **user_input}
             return self.async_create_entry(title="", data=new_options)
-
-        def opt_bool(key: str, default: bool) -> bool:
-            """Read a boolean option with a default."""
-            return bool(options.get(key, default))
 
         # Default enable behaviour (conservative)
         default_enabled_keys = {"s3_temperature", "s4_temperature"}
 
+        def opt_bool(key: str, default: bool) -> bool:
+            return bool(options.get(key, default))
+
         schema_dict: dict[vol.Marker, object] = {}
 
-        # One checkbox per register (both RO + RW are enabled here;
-        # platforms decide how to expose them: sensors vs numbers/selects)
+        # One checkbox per register
         for reg in ALL_REGISTERS:
             k = option_key(reg.key)
             default_value = opt_bool(k, reg.key in default_enabled_keys)
-
-            label = f"{reg.name} ({reg.address})"
-
-            schema_dict[
-                vol.Optional(
-                    k,
-                    default=default_value,
-                    description={"name": label},
-                )
-            ] = bool
+            schema_dict[vol.Optional(k, default=default_value)] = bool
 
         # Global polling interval (seconds)
         schema_dict[

--- a/custom_components/ecl_modbus/manifest.json
+++ b/custom_components/ecl_modbus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ecl_modbus",
   "name": "ECL Modbus",
-  "version": "2.2.0-beta.1",
+  "version": "2.2.0-beta.2",
   "documentation": "https://github.com/nichlasrohde/ha-ecl-modbus",
   "requirements": [],
   "codeowners": ["@nichlasrohde"],

--- a/custom_components/ecl_modbus/manifest.json
+++ b/custom_components/ecl_modbus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ecl_modbus",
   "name": "ECL Modbus",
-  "version": "2.2.0-beta.2",
+  "version": "2.2.0",
   "documentation": "https://github.com/nichlasrohde/ha-ecl-modbus",
   "requirements": [],
   "codeowners": ["@nichlasrohde"],

--- a/custom_components/ecl_modbus/manifest.json
+++ b/custom_components/ecl_modbus/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "ecl_modbus",
   "name": "ECL Modbus",
-  "version": "2.1.0",
+  "version": "2.2.0-beta.1",
   "documentation": "https://github.com/nichlasrohde/ha-ecl-modbus",
   "requirements": [],
   "codeowners": ["@nichlasrohde"],

--- a/custom_components/ecl_modbus/modbus.py
+++ b/custom_components/ecl_modbus/modbus.py
@@ -185,6 +185,14 @@ class EclModbusHub:
         if signed and raw > 0x7FFF:
             raw -= 0x10000
         return raw
+    
+    def read_uint32(self, reg_address_manual: int) -> int | None:
+        """Read an unsigned 32-bit integer from two holding registers (big-endian)."""
+        regs = self._read_registers(reg_address_manual, count=2)
+        if regs is None:
+            return None
+
+        return (regs[0] << 16) | regs[1]
 
     def read_string(self, reg_address_manual: int, reg_count: int) -> str | None:
         regs = self._read_registers(reg_address_manual, count=reg_count)
@@ -264,6 +272,8 @@ class EclModbusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     data[reg.key] = self.hub.read_float(reg.address)
                 elif reg.reg_type == RegisterType.INT16:
                     data[reg.key] = self.hub.read_int16(reg.address, signed=reg.signed)
+                elif reg.reg_type == RegisterType.UINT32:
+                    data[reg.key] = self.hub.read_uint32(reg.address)
                 elif reg.reg_type == RegisterType.STRING16:
                     data[reg.key] = self.hub.read_string(reg.address, reg_count=8)
                 elif reg.reg_type == RegisterType.STRING32:

--- a/custom_components/ecl_modbus/number.py
+++ b/custom_components/ecl_modbus/number.py
@@ -165,6 +165,9 @@ class EclModbusRegisterNumber(CoordinatorEntity, NumberEntity):
                 self._hub.write_float(self._reg.address, float(raw_value))
             elif self._reg.reg_type == RegisterType.INT16:
                 self._hub.write_int16(self._reg.address, int(round(raw_value)))
+            elif self._reg.reg_type == RegisterType.UINT32:
+                # UINT32 is written as 2x16-bit registers (big-endian) in modbus.py hub
+                self._hub.write_uint32(self._reg.address, int(round(raw_value)))
             else:
                 raise ValueError(f"Unsupported writable type: {self._reg.reg_type}")
         except Exception as exc:  # noqa: BLE001
@@ -202,8 +205,8 @@ async def async_setup_entry(
     rw_regs = [
         r for r in regs
         if getattr(r, "writable", False)
-        and r.reg_type in (RegisterType.FLOAT, RegisterType.INT16)
-        and not getattr(r, "value_map", None)  # <-- VIGTIG
+        and r.reg_type in (RegisterType.FLOAT, RegisterType.INT16, RegisterType.UINT32)
+        and not getattr(r, "value_map", None)  # keep enums out of Number (they belong in Select)
     ]
 
     async_add_entities(

--- a/custom_components/ecl_modbus/registers.py
+++ b/custom_components/ecl_modbus/registers.py
@@ -222,6 +222,129 @@ REG_EXTRAS: Final[list[RegisterDef]] = [
 ]
 
 # -----------------------------------------------------------------------------
+# Circuit 1 – Supply temperature (flow temperature / heating curve)
+# DK: Fremløbstemperatur for kreds 1
+# -----------------------------------------------------------------------------
+REG_CIRCUIT1_SUPPLY: Final[list[RegisterDef]] = [
+    # DK: Min. fremløbstemperatur for kreds 1
+    RegisterDef(
+        key="circuit1_supply_temp_min",
+        name="Circuit 1 minimum supply temperature",
+        address=21202,
+        reg_type=RegisterType.FLOAT,
+        unit="°C",
+        device_class="temperature",
+        writable=True,
+        min_value=5,
+        max_value=150,
+        step=1.0,
+    ),
+    # DK: Max. fremløbstemperatur for kreds 1
+    RegisterDef(
+        key="circuit1_supply_temp_max",
+        name="Circuit 1 maximum supply temperature",
+        address=21204,
+        reg_type=RegisterType.FLOAT,
+        unit="°C",
+        device_class="temperature",
+        writable=True,
+        min_value=5,
+        max_value=150,
+        step=1.0,
+    ),
+    # DK: Kurve for kreds 1
+    RegisterDef(
+        key="circuit1_heating_curve",
+        name="Circuit 1 heating curve",
+        address=21246,
+        reg_type=RegisterType.FLOAT,
+        writable=True,
+        min_value=0.1,
+        max_value=4.0,
+        step=0.1,
+        icon="mdi:chart-line",
+    ),
+    # DK: Fremløbstemperatur ved -30°C for kreds 1
+    RegisterDef(
+        key="circuit1_supply_temp_at_minus30",
+        name="Circuit 1 supply temperature at -30 °C",
+        address=21232,
+        reg_type=RegisterType.FLOAT,
+        unit="°C",
+        device_class="temperature",
+        writable=True,
+        min_value=5,
+        max_value=150,
+        step=1.0,
+    ),
+    # DK: Fremløbstemperatur ved -15°C for kreds 1
+    RegisterDef(
+        key="circuit1_supply_temp_at_minus15",
+        name="Circuit 1 supply temperature at -15 °C",
+        address=21234,
+        reg_type=RegisterType.FLOAT,
+        unit="°C",
+        device_class="temperature",
+        writable=True,
+        min_value=5,
+        max_value=150,
+        step=1.0,
+    ),
+    # DK: Fremløbstemperatur ved -5°C for kreds 1
+    RegisterDef(
+        key="circuit1_supply_temp_at_minus5",
+        name="Circuit 1 supply temperature at -5 °C",
+        address=21236,
+        reg_type=RegisterType.FLOAT,
+        unit="°C",
+        device_class="temperature",
+        writable=True,
+        min_value=5,
+        max_value=150,
+        step=1.0,
+    ),
+    # DK: Fremløbstemperatur ved 0°C for kreds 1
+    RegisterDef(
+        key="circuit1_supply_temp_at_0",
+        name="Circuit 1 supply temperature at 0 °C",
+        address=21238,
+        reg_type=RegisterType.FLOAT,
+        unit="°C",
+        device_class="temperature",
+        writable=True,
+        min_value=5,
+        max_value=150,
+        step=1.0,
+    ),
+    # DK: Fremløbstemperatur ved 5°C for kreds 1
+    RegisterDef(
+        key="circuit1_supply_temp_at_5",
+        name="Circuit 1 supply temperature at 5 °C",
+        address=21240,
+        reg_type=RegisterType.FLOAT,
+        unit="°C",
+        device_class="temperature",
+        writable=True,
+        min_value=5,
+        max_value=150,
+        step=1.0,
+    ),
+    # DK: Fremløbstemperatur ved 15°C for kreds 1
+    RegisterDef(
+        key="circuit1_supply_temp_at_15",
+        name="Circuit 1 supply temperature at 15 °C",
+        address=21242,
+        reg_type=RegisterType.FLOAT,
+        unit="°C",
+        device_class="temperature",
+        writable=True,
+        min_value=5,
+        max_value=150,
+        step=1.0,
+    ),
+]
+
+# -----------------------------------------------------------------------------
 # Single list of all registers we *can* expose.
 # The integration can later decide which ones to enable via options.
 # -----------------------------------------------------------------------------
@@ -230,6 +353,7 @@ ALL_REGISTERS: Final[list[RegisterDef]] = [
     *REG_SENSORS,
     *REG_DIAGNOSTICS,
     *REG_EXTRAS,
+    *REG_CIRCUIT1_SUPPLY,
 ]
 
 


### PR DESCRIPTION
This pull request adds support for additional ECL registers and control parameters.

Changes include:
- New writable control registers (PID Xp, Tn, Nz, Boost parameters)
- Support for UINT32 registers
- Improved scaling and rounding
- Extended Number entity support for new register types

Tested on:
- Danfoss ECL 120
- Modbus RTU (USB)

Feedback and testing on ECL 220 are very welcome.